### PR TITLE
Filter plots by criteria (platform, API, key size)

### DIFF
--- a/src/default_index.html
+++ b/src/default_index.html
@@ -248,7 +248,7 @@
                                     api,
                                     keySize,
                                     platform,
-                                    x: dataset.map((d) => new Date(d.commit.timestamp)),
+                                    x: dataset.map((d) => d.commit.timestamp),
                                     y: dataset.map((d) => d.bench.value),
                                     // tooltip
                                     text: dataset.map(

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -131,20 +131,36 @@
 
                 function init() {
                     function collectBenchesPerTestCase(entries) {
+                        // collect in nested map
                         const map = new Map();
                         for (const entry of entries) {
-                            const { commit, date, tool, benches } = entry;
+                            const { commit, date, benches } = entry;
                             for (const bench of benches) {
-                                const result = { commit, date, tool, bench };
-                                const arr = map.get(bench.name);
+                                const result = { commit, date, bench };
+
+                                if (map.get(bench.name) === undefined) {
+                                    map.set(bench.name, new Map());
+                                }
+
+                                const by_platform = map.get(bench.name);
+                                const arr = by_platform.get(bench.platform);
                                 if (arr === undefined) {
-                                    map.set(bench.name, [result]);
+                                    by_platform.set(bench.platform, [result]);
                                 } else {
                                     arr.push(result);
                                 }
                             }
                         }
-                        return map;
+
+                        // flatten
+                        const newMap = new Map();
+                        for (let [name, innerMap] of map) {
+                            for (let [platform, arr] of innerMap) {
+                                const key = { name, platform };
+                                newMap.set(key, arr);
+                            }
+                        }
+                        return newMap;
                     }
 
                     const data = window.BENCHMARK_DATA;
@@ -162,29 +178,94 @@
                     }));
                 }
 
+                function createTitle(parent, name) {
+                    const nameElem = document.createElement('h1');
+                    nameElem.className = 'benchmark-title';
+                    nameElem.textContent = name;
+                    parent.appendChild(nameElem);
+                }
+
                 // input: separated-out datasets
                 function renderAllCharts(dataSets) {
-                    function renderGraph(parent, dataSets) {
+                    function chartByApiAndPlatform(parent, api, platform, datasets, layout) {
+                        const filtered = Array.from(datasets.filter((d) => d.api == api && d.platform == platform));
+                        // return if no datasets
+                        if (filtered.length == 0) {
+                            console.log(`No datasets found with api "${api}" and platform ${platform}`);
+                            return;
+                        }
+                        layout.title = { text: `${api} (platform: ${platform})` };
+                        Plotly.newPlot(parent, filtered, layout);
+                    }
+
+                    function chartByKeySize(parent, keySize, datasets, layout) {
+                        const filtered = Array.from(datasets.filter((d) => d.keySize == keySize));
+                        // return if no datasets
+                        if (filtered.length == 0) {
+                            console.log(`No datasets found with keySize ${keySize}`);
+                            return;
+                        }
+                        layout.title = { text: `All benchmarks for key size ${keySize}` };
+                        Plotly.newPlot(parent, filtered, layout);
+                    }
+                    function chartByPlatform(parent, platform, datasets, layout) {
+                        const filtered = Array.from(datasets.filter((d) => d.platform == platform));
+                        // return if no datasets
+                        if (filtered.length == 0) {
+                            console.log(`No datasets found with platform ${platform}`);
+                            return;
+                        }
+                        layout.title = {
+                            text: `All benchmarks for platform "${platform}"`,
+                        };
+                        Plotly.newPlot(parent, filtered, layout);
+                    }
+
+                    function buildPlotConfig(dataSets) {
                         const datasets = Array.from(
-                            dataSets.dataSet.entries().map(([name, dataset], index) => {
+                            dataSets.dataSet.entries().map(([key, dataset], index) => {
+                                const name = key.name;
+                                const platform = key.platform;
+
+                                const name_info = name.split(' ');
+
+                                const name_with_platform = name.concat(` (platform: ${platform})`);
+
+                                // Extract the numeric component from the second substring
+                                // as the key size.
+                                // TODO: the data is not guaranteed to be in this format.
+                                // Will need to retrieve this info a different way,
+                                // or guarantee that the name specified in the `cargo bench` output
+                                // has the keySize in this location.
+                                const keySizeStr = name_info[1].replace(/[^0-9]/g, '');
+                                const keySize = parseInt(keySizeStr, 10);
+
+                                // remove key size from name to get api name
+                                // NOTE: The data is not guaranteed to be in this format.
+                                const api = name_info[0].concat(' ').concat(name_info.slice(2).join(' '));
+
                                 return {
-                                    name: name,
+                                    name: name_with_platform,
+                                    api,
+                                    keySize,
+                                    platform,
+                                    x: dataset.map((d) => d.date),
                                     y: dataset.map((d) => d.bench.value),
+                                    // tooltip
+                                    text: dataset.map((d) => `${d.bench.value} ${d.bench.unit}`),
+                                    showlegend: true,
+                                    hoverinfo: 'text',
                                 };
                             }),
                         );
 
-                        const canvas = document.createElement('canvas');
-                        canvas.className = 'benchmark-chart';
-                        parent.appendChild(canvas);
-
                         // TODO: more config
                         const layout = {
-                            width: 1200,
                             height: 600,
+                            width: 1200,
                         };
 
-                        const plot = Plotly.newPlot(parent, datasets, layout);
+                        return [datasets, layout];
                     }
 
                     const main = document.getElementById('main');
@@ -192,16 +273,41 @@
                     setElem.className = 'benchmark-set';
                     main.appendChild(setElem);
 
-                    const nameElem = document.createElement('h1');
-                    nameElem.className = 'benchmark-title';
-                    nameElem.textContent = 'All benchmarks';
-                    setElem.appendChild(nameElem);
+                    const [datasets, layout] = buildPlotConfig(dataSets[0]);
 
-                    const graphsElem = document.createElement('div');
-                    graphsElem.className = 'benchmark-graphs';
-                    setElem.appendChild(graphsElem);
+                    const platforms = [...new Set(datasets.map((d) => d.platform))];
 
-                    renderGraph(graphsElem, dataSets[0]);
+                    // plots by api
+                    createTitle(setElem, 'Plots by API');
+                    const apis = [...new Set(datasets.map((d) => d.api))];
+                    for (let api of apis) {
+                        for (let platform of platforms) {
+                            const graphsElem = document.createElement('div');
+                            graphsElem.className = 'benchmark-graphs';
+                            setElem.appendChild(graphsElem);
+                            chartByApiAndPlatform(graphsElem, api, platform, datasets, layout);
+                        }
+                    }
+
+                    // plots by key size
+                    createTitle(setElem, 'Plots by key size');
+                    const keySizes = [...new Set(datasets.map((d) => d.keySize))];
+                    for (let keySize of keySizes) {
+                        if (!isNaN(keySize)) {
+                            const graphsElem = document.createElement('div');
+                            graphsElem.className = 'benchmark-graphs';
+                            setElem.appendChild(graphsElem);
+                            chartByKeySize(graphsElem, keySize, datasets, layout);
+                        }
+                    }
+                    // plots by platform
+                    createTitle(setElem, 'Plots by platform');
+                    for (let platform of platforms) {
+                        const graphsElem = document.createElement('div');
+                        graphsElem.className = 'benchmark-graphs';
+                        setElem.appendChild(graphsElem);
+                        chartByPlatform(graphsElem, platform, datasets, layout);
+                    }
                 }
 
                 renderAllCharts(init()); // Start

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -187,14 +187,24 @@
 
                 // input: separated-out datasets
                 function renderAllCharts(dataSets) {
+                    function chartByApiAndKeySize(parent, api, keySize, datasets, layout) {
+                        const filtered = Array.from(datasets.filter((d) => d.api == api && d.keySize == keySize));
+                        // return if no datasets
+                        if (filtered.length == 0) {
+                            console.log(`No datasets found with api "${api} and keySize ${keySize}"`);
+                            return;
+                        }
+                        layout.title = { text: `${api}` };
+                        Plotly.newPlot(parent, filtered, layout);
+                    }
                     function chartByApiAndPlatform(parent, api, platform, datasets, layout) {
                         const filtered = Array.from(datasets.filter((d) => d.api == api && d.platform == platform));
                         // return if no datasets
                         if (filtered.length == 0) {
-                            console.log(`No datasets found with api "${api}" and platform ${platform}`);
+                            console.log(`No datasets found with api "${api} and platform ${platform}"`);
                             return;
                         }
-                        layout.title = { text: `${api} (platform: ${platform})` };
+                        layout.title = { text: `${api}` };
                         Plotly.newPlot(parent, filtered, layout);
                     }
 
@@ -224,12 +234,20 @@
                     function buildPlotConfig(dataSets) {
                         const datasets = Array.from(
                             dataSets.dataSet.entries().map(([key, dataset], index) => {
-                                const name = key.name;
+                                let name = key.name;
                                 const platform = key.platform;
 
+                                // remove the unneeded 'portable' prefix
+                                // TODO: standardize the benchmark name format
+                                if (name.startsWith('portable')) {
+                                    name = name.slice('portable '.length);
+                                    if (!name.includes('portable')) {
+                                        name = name.concat('/portable');
+                                    }
+                                }
                                 const name_info = name.split(' ');
 
-                                const name_with_platform = name.concat(` (platform: ${platform})`);
+                                const name_with_platform = key.name.concat(` (platform: ${platform})`);
 
                                 // Extract the numeric component from the second substring
                                 // as the key size.
@@ -250,11 +268,12 @@
                                     api,
                                     keySize,
                                     platform,
-                                    x: dataset.map((d) => new Date(d.date)),
+                                    x: dataset.map((d) => new Date(d.commit.timestamp)),
                                     y: dataset.map((d) => d.bench.value),
                                     // tooltip
                                     text: dataset.map(
-                                        (d) => `${d.bench.value} ${d.bench.unit} (commit: ${d.commit.message})`,
+                                        (d) =>
+                                            `<b>${name}</b><br>platform: ${platform}<br>value: ${d.bench.value} ${d.bench.unit} ${d.bench.range}<br>commit id: ${d.commit.id}<br>commit name: ${d.commit.message}<br>commit url: ${d.commit.url}`,
                                     ),
                                     showlegend: true,
                                     hoverinfo: 'text',
@@ -279,38 +298,29 @@
 
                     const [datasets, layout] = buildPlotConfig(dataSets[0]);
 
-                    const platforms = [...new Set(datasets.map((d) => d.platform))];
-
-                    // plots by api
-                    createTitle(setElem, 'Plots by API and platform');
                     const apis = [...new Set(datasets.map((d) => d.api))];
-                    for (let api of apis) {
-                        for (let platform of platforms) {
-                            const graphsElem = document.createElement('div');
-                            graphsElem.className = 'benchmark-graphs';
-                            setElem.appendChild(graphsElem);
-                            chartByApiAndPlatform(graphsElem, api, platform, datasets, layout);
-                        }
-                    }
-
-                    // plots by key size
-                    createTitle(setElem, 'Plots by key size');
                     const keySizes = [...new Set(datasets.map((d) => d.keySize))];
-                    for (let keySize of keySizes) {
-                        if (!isNaN(keySize)) {
-                            const graphsElem = document.createElement('div');
-                            graphsElem.className = 'benchmark-graphs';
-                            setElem.appendChild(graphsElem);
-                            chartByKeySize(graphsElem, keySize, datasets, layout);
-                        }
-                    }
+
                     // plots by platform
-                    createTitle(setElem, 'Plots by platform');
-                    for (let platform of platforms) {
+                    createTitle(setElem, 'Plots by API');
+                    for (let api of apis) {
                         const graphsElem = document.createElement('div');
                         graphsElem.className = 'benchmark-graphs';
                         setElem.appendChild(graphsElem);
-                        chartByPlatform(graphsElem, platform, datasets, layout);
+                        chartByApiAndPlatform(graphsElem, api, 'ubuntu-latest_64', datasets, layout);
+                    }
+
+                    // plots by api
+                    createTitle(setElem, 'Plots by API and key size');
+                    for (let api of apis) {
+                        for (let keySize of keySizes) {
+                            if (!isNaN(keySize)) {
+                                const graphsElem = document.createElement('div');
+                                graphsElem.className = 'benchmark-graphs';
+                                setElem.appendChild(graphsElem);
+                                chartByApiAndKeySize(graphsElem, api, keySize, datasets, layout);
+                            }
+                        }
                     }
                 }
 

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -237,7 +237,8 @@
                                 // Will need to retrieve this info a different way,
                                 // or guarantee that the name specified in the `cargo bench` output
                                 // has the keySize in this location.
-                                const keySizeStr = name_info[1].replace(/[^0-9]/g, '');
+                                const keySizeStr =
+                                    name_info[1] !== undefined ? name_info[1].replace(/[^0-9]/g, '') : '';
                                 const keySize = parseInt(keySizeStr, 10);
 
                                 // remove key size from name to get api name

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -80,9 +80,6 @@
                 flex-wrap: wrap;
                 width: 100%;
             }
-            .benchmark-chart {
-                max-width: 1000px;
-            }
         </style>
         <title>Benchmarks</title>
     </head>
@@ -112,23 +109,6 @@
         <script id="main-script">
             'use strict';
             (function () {
-                // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-                const colors = [
-                    '#dea584',
-                    '#00add8',
-                    '#f1e05a',
-                    '#000080',
-                    '#3572a5',
-                    '#f34b7d',
-                    '#f34b7d',
-                    '#a270ba',
-                    '#b07219',
-                    '#178600',
-                    '#38ff38',
-                    '#ff3838',
-                    '#333333',
-                ];
-
                 function init() {
                     function collectBenchesPerTestCase(entries) {
                         // collect in nested map

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -250,10 +250,12 @@
                                     api,
                                     keySize,
                                     platform,
-                                    x: dataset.map((d) => d.date),
+                                    x: dataset.map((d) => new Date(d.date)),
                                     y: dataset.map((d) => d.bench.value),
                                     // tooltip
-                                    text: dataset.map((d) => `${d.bench.value} ${d.bench.unit}`),
+                                    text: dataset.map(
+                                        (d) => `${d.bench.value} ${d.bench.unit} (commit: ${d.commit.message})`,
+                                    ),
                                     showlegend: true,
                                     hoverinfo: 'text',
                                 };
@@ -264,6 +266,7 @@
                         const layout = {
                             height: 600,
                             width: 1200,
+                            xaxis: { type: 'date' },
                         };
 
                         return [datasets, layout];

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -282,7 +282,7 @@
                     const keySizes = [...new Set(datasets.map((d) => d.keySize))];
 
                     // plots by platform
-                    createTitle(setElem, 'Plots by API');
+                    createTitle(setElem, 'API plots');
                     for (let api of apis) {
                         const graphsElem = document.createElement('div');
                         graphsElem.className = 'benchmark-graphs';
@@ -291,7 +291,7 @@
                     }
 
                     // plots by api
-                    createTitle(setElem, 'Plots by API and key size');
+                    createTitle(setElem, 'API and key size plots');
                     for (let api of apis) {
                         for (let keySize of keySizes) {
                             if (!isNaN(keySize)) {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -111,36 +111,42 @@
             (function () {
                 function init() {
                     function collectBenchesPerTestCase(entries) {
+                        // TODO: collect by all fields in `bench`
                         // collect in nested map
                         const map = new Map();
                         for (const entry of entries) {
                             const { commit, date, benches } = entry;
                             for (const bench of benches) {
+                                let name = bench.name;
+                                let platform = bench.platform;
+                                let os = bench.os;
+                                let keySize = bench.keySize;
+                                let api = bench.api;
+                                let category = bench.category;
+
+                                let key = JSON.stringify({ name, platform, os, keySize, api, category });
                                 const result = { commit, date, bench };
 
-                                if (map.get(bench.name) === undefined) {
-                                    map.set(bench.name, new Map());
-                                }
-
-                                const by_platform = map.get(bench.name);
-                                const arr = by_platform.get(bench.platform);
+                                const arr = map.get(key);
                                 if (arr === undefined) {
-                                    by_platform.set(bench.platform, [result]);
+                                    map.set(key, [result]);
                                 } else {
                                     arr.push(result);
                                 }
                             }
                         }
 
-                        // flatten
-                        const newMap = new Map();
-                        for (let [name, innerMap] of map) {
-                            for (let [platform, arr] of innerMap) {
-                                const key = { name, platform };
-                                newMap.set(key, arr);
-                            }
-                        }
-                        return newMap;
+                        // replace the key with data
+                        const data = Array.from(map.entries())
+                            .map(([key, value]) => {
+                                const d = JSON.parse(key);
+                                d.dataset = value;
+                                return d;
+                            })
+                            // TODO: remove this filter
+                            .filter((e) => e.api !== undefined);
+
+                        return data;
                     }
 
                     const data = window.BENCHMARK_DATA;
@@ -167,86 +173,35 @@
 
                 // input: separated-out datasets
                 function renderAllCharts(dataSets) {
-                    function chartByApiAndKeySize(parent, api, keySize, datasets, layout) {
-                        const filtered = Array.from(datasets.filter((d) => d.api == api && d.keySize == keySize));
+                    function chartByOsAndKeySize(parent, os, keySize, datasets, layout) {
+                        const filtered = Array.from(
+                            datasets
+                                .filter((d) => d.os == os && d.keySize == keySize)
+                                .map((d) => {
+                                    d.name = `${d.name} - ${d.api} - ${d.platform}`;
+                                    return d;
+                                }),
+                        );
                         // return if no datasets
                         if (filtered.length == 0) {
                             console.log(`No datasets found with api "${api} and keySize ${keySize}"`);
                             return;
                         }
-                        layout.title = { text: `${api} ${keySize}` };
-                        Plotly.newPlot(parent, filtered, layout);
-                    }
-                    function chartByApiAndPlatform(parent, api, platform, datasets, layout) {
-                        const filtered = Array.from(datasets.filter((d) => d.api == api && d.platform == platform));
-                        // return if no datasets
-                        if (filtered.length == 0) {
-                            console.log(`No datasets found with api "${api} and platform ${platform}"`);
-                            return;
-                        }
-                        layout.title = { text: `${api}` };
-                        Plotly.newPlot(parent, filtered, layout);
-                    }
-
-                    function chartByKeySize(parent, keySize, datasets, layout) {
-                        const filtered = Array.from(datasets.filter((d) => d.keySize == keySize));
-                        // return if no datasets
-                        if (filtered.length == 0) {
-                            console.log(`No datasets found with keySize ${keySize}`);
-                            return;
-                        }
-                        layout.title = { text: `All benchmarks for key size ${keySize}` };
-                        Plotly.newPlot(parent, filtered, layout);
-                    }
-                    function chartByPlatform(parent, platform, datasets, layout) {
-                        const filtered = Array.from(datasets.filter((d) => d.platform == platform));
-                        // return if no datasets
-                        if (filtered.length == 0) {
-                            console.log(`No datasets found with platform ${platform}`);
-                            return;
-                        }
-                        layout.title = {
-                            text: `All benchmarks for platform "${platform}"`,
-                        };
+                        layout.title = { text: `OS: ${os}, keySize: ${keySize}` };
                         Plotly.newPlot(parent, filtered, layout);
                     }
 
                     function buildPlotConfig(dataSets) {
                         const datasets = Array.from(
-                            dataSets.dataSet.entries().map(([key, dataset], index) => {
-                                let name = key.name;
-                                const platform = key.platform;
-
-                                // remove the unneeded 'portable' prefix
-                                // TODO: standardize the benchmark name format
-                                if (name.startsWith('portable')) {
-                                    name = name.slice('portable '.length);
-                                    if (!name.includes('portable')) {
-                                        name = name.concat('/portable');
-                                    }
-                                }
-                                const name_info = name.split(' ');
-
-                                const name_with_platform = key.name.concat(` (platform: ${platform})`);
-
-                                // Extract the numeric component from the second substring
-                                // as the key size.
-                                // TODO: the data is not guaranteed to be in this format.
-                                // Will need to retrieve this info a different way,
-                                // or guarantee that the name specified in the `cargo bench` output
-                                // has the keySize in this location.
-                                const keySizeStr =
-                                    name_info[1] !== undefined ? name_info[1].replace(/[^0-9]/g, '') : '';
-                                const keySize = parseInt(keySizeStr, 10);
-
-                                // remove key size from name to get api name
-                                // NOTE: The data is not guaranteed to be in this format.
-                                const api = name_info[0].concat(' ').concat(name_info.slice(2).join(' '));
+                            dataSets.dataSet.map((item) => {
+                                let { name, api, keySize, category, os, platform, dataset } = item;
 
                                 return {
-                                    name: name_with_platform,
+                                    category,
+                                    name,
                                     api,
                                     keySize,
+                                    os,
                                     platform,
                                     x: dataset.map((d) => d.commit.timestamp),
                                     y: dataset.map((d) => d.bench.value),
@@ -278,27 +233,18 @@
 
                     const [datasets, layout] = buildPlotConfig(dataSets[0]);
 
-                    const apis = [...new Set(datasets.map((d) => d.api))];
+                    const osList = [...new Set(datasets.map((d) => d.os))];
                     const keySizes = [...new Set(datasets.map((d) => d.keySize))];
 
-                    // plots by platform
-                    createTitle(setElem, 'Compare key size for API');
-                    for (let api of apis) {
-                        const graphsElem = document.createElement('div');
-                        graphsElem.className = 'benchmark-graphs';
-                        setElem.appendChild(graphsElem);
-                        chartByApiAndPlatform(graphsElem, api, 'ubuntu-latest_64', datasets, layout);
-                    }
-
-                    // plots by api
-                    createTitle(setElem, 'Compare platform for API/key size');
-                    for (let api of apis) {
+                    // plots by OS/Key Size
+                    createTitle(setElem, 'Compare platform for OS/key size');
+                    for (let os of osList) {
                         for (let keySize of keySizes) {
                             if (!isNaN(keySize)) {
                                 const graphsElem = document.createElement('div');
                                 graphsElem.className = 'benchmark-graphs';
                                 setElem.appendChild(graphsElem);
-                                chartByApiAndKeySize(graphsElem, api, keySize, datasets, layout);
+                                chartByOsAndKeySize(graphsElem, os, keySize, datasets, layout);
                             }
                         }
                     }

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -1,4 +1,4 @@
-export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -229,4 +229,3 @@ export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
     </script>
   </body>
 </html>
-`;

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -137,15 +137,11 @@
                         }
 
                         // replace the key with data
-                        const data = Array.from(map.entries())
-                            .map(([key, value]) => {
-                                const d = JSON.parse(key);
-                                d.dataset = value;
-                                return d;
-                            })
-                            // TODO: remove this filter
-                            .filter((e) => e.api !== undefined);
-
+                        const data = Array.from(map.entries()).map(([key, value]) => {
+                            const d = JSON.parse(key);
+                            d.dataset = value;
+                            return d;
+                        });
                         return data;
                     }
 
@@ -184,7 +180,7 @@
                         );
                         // return if no datasets
                         if (filtered.length == 0) {
-                            console.log(`No datasets found with api "${api} and keySize ${keySize}"`);
+                            console.log(`No datasets found with os "${os} and keySize ${keySize}"`);
                             return;
                         }
                         layout.title = { text: `OS: ${os}, keySize: ${keySize}` };

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -172,7 +172,14 @@
                     function chartByOsAndKeySize(parent, os, keySize, datasets, layout) {
                         const filtered = Array.from(
                             datasets
-                                .filter((d) => d.os == os && d.keySize == keySize)
+                                .filter(
+                                    (d) =>
+                                        d.os == os &&
+                                        d.keySize == keySize &&
+                                        d.name !== undefined &&
+                                        d.api !== undefined &&
+                                        d.platform !== undefined,
+                                )
                                 .map((d) => {
                                     d.name = `${d.name} - ${d.api} - ${d.platform}`;
                                     return d;

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -180,11 +180,17 @@
                                         d.api !== undefined &&
                                         d.platform !== undefined,
                                 )
-                                .map((d) => {
-                                    d.name = `${d.name} - ${d.api} - ${d.platform}`;
-                                    return d;
+                                .map((trace) => {
+                                    trace.name = `${trace.name} - ${trace.api} - ${trace.platform}`;
+                                    // tooltip
+                                    trace.text = trace.dataset.map(
+                                        (d) =>
+                                            `<b>${trace.name}</b><br>value: ${d.bench.value} ${d.bench.unit} ${d.bench.range}<br>commit id: ${d.commit.id}<br>commit name: ${d.commit.message}<br>commit url: ${d.commit.url}`,
+                                    );
+                                    return trace;
                                 }),
                         );
+
                         // return if no datasets
                         if (filtered.length == 0) {
                             console.log(`No datasets found with os "${os} and keySize ${keySize}"`);
@@ -208,11 +214,7 @@
                                     platform,
                                     x: dataset.map((d) => d.commit.timestamp),
                                     y: dataset.map((d) => d.bench.value),
-                                    // tooltip
-                                    text: dataset.map(
-                                        (d) =>
-                                            `<b>${name}</b><br>platform: ${platform}<br>value: ${d.bench.value} ${d.bench.unit} ${d.bench.range}<br>commit id: ${d.commit.id}<br>commit name: ${d.commit.message}<br>commit url: ${d.commit.url}`,
-                                    ),
+                                    dataset,
                                     showlegend: true,
                                     hoverinfo: 'text',
                                 };

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -1,231 +1,211 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes"
-    />
-    <style>
-      html {
-        font-family:
-          BlinkMacSystemFont,
-          -apple-system,
-          "Segoe UI",
-          Roboto,
-          Oxygen,
-          Ubuntu,
-          Cantarell,
-          "Fira Sans",
-          "Droid Sans",
-          "Helvetica Neue",
-          Helvetica,
-          Arial,
-          sans-serif;
-        -webkit-font-smoothing: antialiased;
-        background-color: #fff;
-        font-size: 16px;
-      }
-      body {
-        color: #4a4a4a;
-        margin: 8px;
-        font-size: 1em;
-        font-weight: 400;
-      }
-      header {
-        margin-bottom: 8px;
-        display: flex;
-        flex-direction: column;
-      }
-      main {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      a {
-        color: #3273dc;
-        cursor: pointer;
-        text-decoration: none;
-      }
-      a:hover {
-        color: #000;
-      }
-      button {
-        color: #fff;
-        background-color: #3298dc;
-        border-color: transparent;
-        cursor: pointer;
-        text-align: center;
-      }
-      button:hover {
-        background-color: #2793da;
-        flex: none;
-      }
-      .spacer {
-        flex: auto;
-      }
-      .small {
-        font-size: 0.75rem;
-      }
-      footer {
-        margin-top: 16px;
-        display: flex;
-        align-items: center;
-      }
-      .header-label {
-        margin-right: 4px;
-      }
-      .benchmark-set {
-        margin: 8px 0;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-      }
-      .benchmark-title {
-        font-size: 3rem;
-        font-weight: 600;
-        word-break: break-word;
-        text-align: center;
-      }
-      .benchmark-graphs {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        align-items: center;
-        flex-wrap: wrap;
-        width: 100%;
-      }
-      .benchmark-chart {
-        max-width: 1000px;
-      }
-    </style>
-    <title>Benchmarks</title>
-  </head>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+        <style>
+            html {
+                font-family: BlinkMacSystemFont, -apple-system, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+                    'Fira Sans', 'Droid Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+                -webkit-font-smoothing: antialiased;
+                background-color: #fff;
+                font-size: 16px;
+            }
+            body {
+                color: #4a4a4a;
+                margin: 8px;
+                font-size: 1em;
+                font-weight: 400;
+            }
+            header {
+                margin-bottom: 8px;
+                display: flex;
+                flex-direction: column;
+            }
+            main {
+                width: 100%;
+                display: flex;
+                flex-direction: column;
+            }
+            a {
+                color: #3273dc;
+                cursor: pointer;
+                text-decoration: none;
+            }
+            a:hover {
+                color: #000;
+            }
+            button {
+                color: #fff;
+                background-color: #3298dc;
+                border-color: transparent;
+                cursor: pointer;
+                text-align: center;
+            }
+            button:hover {
+                background-color: #2793da;
+                flex: none;
+            }
+            .spacer {
+                flex: auto;
+            }
+            .small {
+                font-size: 0.75rem;
+            }
+            footer {
+                margin-top: 16px;
+                display: flex;
+                align-items: center;
+            }
+            .header-label {
+                margin-right: 4px;
+            }
+            .benchmark-set {
+                margin: 8px 0;
+                width: 100%;
+                display: flex;
+                flex-direction: column;
+            }
+            .benchmark-title {
+                font-size: 3rem;
+                font-weight: 600;
+                word-break: break-word;
+                text-align: center;
+            }
+            .benchmark-graphs {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-around;
+                align-items: center;
+                flex-wrap: wrap;
+                width: 100%;
+            }
+            .benchmark-chart {
+                max-width: 1000px;
+            }
+        </style>
+        <title>Benchmarks</title>
+    </head>
 
-  <body>
-    <header id="header">
-      <div class="header-item">
-        <strong class="header-label">Last Update:</strong>
-        <span id="last-update"></span>
-      </div>
-      <div class="header-item">
-        <strong class="header-label">Repository:</strong>
-        <a id="repository-link" rel="noopener"></a>
-      </div>
-    </header>
-    <main id="main"></main>
-    <footer>
-      <!--
+    <body>
+        <header id="header">
+            <div class="header-item">
+                <strong class="header-label">Last Update:</strong>
+                <span id="last-update"></span>
+            </div>
+            <div class="header-item">
+                <strong class="header-label">Repository:</strong>
+                <a id="repository-link" rel="noopener"></a>
+            </div>
+        </header>
+        <main id="main"></main>
+        <footer>
+            <!--
       <button id="dl-button">Download data as JSON</button>
       <div class="spacer"></div>
       <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
        -->
-    </footer>
+        </footer>
 
-    <script
-      src="https://cdn.plot.ly/plotly-3.0.0.min.js"
-      charset="utf-8"
-    ></script>
-    <script src="data.js"></script>
-    <script id="main-script">
-      "use strict";
-      (function () {
-        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
-        const colors = [
-          "#dea584",
-          "#00add8",
-          "#f1e05a",
-          "#000080",
-          "#3572a5",
-          "#f34b7d",
-          "#f34b7d",
-          "#a270ba",
-          "#b07219",
-          "#178600",
-          "#38ff38",
-          "#ff3838",
-          "#333333",
-        ];
+        <script src="https://cdn.plot.ly/plotly-3.0.0.min.js" charset="utf-8"></script>
+        <script src="data.js"></script>
+        <script id="main-script">
+            'use strict';
+            (function () {
+                // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+                const colors = [
+                    '#dea584',
+                    '#00add8',
+                    '#f1e05a',
+                    '#000080',
+                    '#3572a5',
+                    '#f34b7d',
+                    '#f34b7d',
+                    '#a270ba',
+                    '#b07219',
+                    '#178600',
+                    '#38ff38',
+                    '#ff3838',
+                    '#333333',
+                ];
 
-        function init() {
-          function collectBenchesPerTestCase(entries) {
-            const map = new Map();
-            for (const entry of entries) {
-              const { commit, date, tool, benches } = entry;
-              for (const bench of benches) {
-                const result = { commit, date, tool, bench };
-                const arr = map.get(bench.name);
-                if (arr === undefined) {
-                  map.set(bench.name, [result]);
-                } else {
-                  arr.push(result);
+                function init() {
+                    function collectBenchesPerTestCase(entries) {
+                        const map = new Map();
+                        for (const entry of entries) {
+                            const { commit, date, tool, benches } = entry;
+                            for (const bench of benches) {
+                                const result = { commit, date, tool, bench };
+                                const arr = map.get(bench.name);
+                                if (arr === undefined) {
+                                    map.set(bench.name, [result]);
+                                } else {
+                                    arr.push(result);
+                                }
+                            }
+                        }
+                        return map;
+                    }
+
+                    const data = window.BENCHMARK_DATA;
+
+                    // Render header
+                    document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
+                    const repoLink = document.getElementById('repository-link');
+                    repoLink.href = data.repoUrl;
+                    repoLink.textContent = data.repoUrl;
+
+                    // Prepare data points for charts
+                    return Object.keys(data.entries).map((name) => ({
+                        name,
+                        dataSet: collectBenchesPerTestCase(data.entries[name]),
+                    }));
                 }
-              }
-            }
-            return map;
-          }
 
-          const data = window.BENCHMARK_DATA;
+                // input: separated-out datasets
+                function renderAllCharts(dataSets) {
+                    function renderGraph(parent, dataSets) {
+                        const datasets = Array.from(
+                            dataSets.dataSet.entries().map(([name, dataset], index) => {
+                                return {
+                                    name: name,
+                                    y: dataset.map((d) => d.bench.value),
+                                };
+                            }),
+                        );
 
-          // Render header
-          document.getElementById("last-update").textContent = new Date(
-            data.lastUpdate,
-          ).toString();
-          const repoLink = document.getElementById("repository-link");
-          repoLink.href = data.repoUrl;
-          repoLink.textContent = data.repoUrl;
+                        const canvas = document.createElement('canvas');
+                        canvas.className = 'benchmark-chart';
+                        parent.appendChild(canvas);
 
-          // Prepare data points for charts
-          return Object.keys(data.entries).map((name) => ({
-            name,
-            dataSet: collectBenchesPerTestCase(data.entries[name]),
-          }));
-        }
+                        // TODO: more config
+                        const layout = {
+                            width: 1200,
+                            height: 600,
+                        };
 
-        // input: separated-out datasets
-        function renderAllCharts(dataSets) {
-          function renderGraph(parent, dataSets) {
-            const datasets = Array.from(
-              dataSets.dataSet.entries().map(([name, dataset], index) => {
-                return {
-                  name: name,
-                  y: dataset.map((d) => d.bench.value),
-                };
-              }),
-            );
+                        const plot = Plotly.newPlot(parent, datasets, layout);
+                    }
 
-            const canvas = document.createElement("canvas");
-            canvas.className = "benchmark-chart";
-            parent.appendChild(canvas);
+                    const main = document.getElementById('main');
+                    const setElem = document.createElement('div');
+                    setElem.className = 'benchmark-set';
+                    main.appendChild(setElem);
 
-            // TODO: more config
-            const layout = {
-              width: 1200,
-              height: 600,
-            };
+                    const nameElem = document.createElement('h1');
+                    nameElem.className = 'benchmark-title';
+                    nameElem.textContent = 'All benchmarks';
+                    setElem.appendChild(nameElem);
 
-            const plot = Plotly.newPlot(parent, datasets, layout);
-          }
+                    const graphsElem = document.createElement('div');
+                    graphsElem.className = 'benchmark-graphs';
+                    setElem.appendChild(graphsElem);
 
-          const main = document.getElementById("main");
-          const setElem = document.createElement("div");
-          setElem.className = "benchmark-set";
-          main.appendChild(setElem);
+                    renderGraph(graphsElem, dataSets[0]);
+                }
 
-          const nameElem = document.createElement("h1");
-          nameElem.className = "benchmark-title";
-          nameElem.textContent = "All benchmarks";
-          setElem.appendChild(nameElem);
-
-          const graphsElem = document.createElement("div");
-          graphsElem.className = "benchmark-graphs";
-          setElem.appendChild(graphsElem);
-
-          renderGraph(graphsElem, dataSets[0]);
-        }
-
-        renderAllCharts(init()); // Start
-      })();
-    </script>
-  </body>
+                renderAllCharts(init()); // Start
+            })();
+        </script>
+    </body>
 </html>

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -282,7 +282,7 @@
                     const platforms = [...new Set(datasets.map((d) => d.platform))];
 
                     // plots by api
-                    createTitle(setElem, 'Plots by API');
+                    createTitle(setElem, 'Plots by API and platform');
                     const apis = [...new Set(datasets.map((d) => d.api))];
                     for (let api of apis) {
                         for (let platform of platforms) {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -174,7 +174,7 @@
                             console.log(`No datasets found with api "${api} and keySize ${keySize}"`);
                             return;
                         }
-                        layout.title = { text: `${api}` };
+                        layout.title = { text: `${api} ${keySize}` };
                         Plotly.newPlot(parent, filtered, layout);
                     }
                     function chartByApiAndPlatform(parent, api, platform, datasets, layout) {
@@ -282,7 +282,7 @@
                     const keySizes = [...new Set(datasets.map((d) => d.keySize))];
 
                     // plots by platform
-                    createTitle(setElem, 'API plots');
+                    createTitle(setElem, 'Compare key size for API');
                     for (let api of apis) {
                         const graphsElem = document.createElement('div');
                         graphsElem.className = 'benchmark-graphs';
@@ -291,7 +291,7 @@
                     }
 
                     // plots by api
-                    createTitle(setElem, 'API and key size plots');
+                    createTitle(setElem, 'Compare platform for API/key size');
                     for (let api of apis) {
                         for (let keySize of keySizes) {
                             if (!isNaN(keySize)) {

--- a/src/default_index_html.ts
+++ b/src/default_index_html.ts
@@ -2,10 +2,26 @@ export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
+    <meta
+      name="viewport"
+      content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes"
+    />
     <style>
       html {
-        font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+        font-family:
+          BlinkMacSystemFont,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          "Fira Sans",
+          "Droid Sans",
+          "Helvetica Neue",
+          Helvetica,
+          Arial,
+          sans-serif;
         -webkit-font-smoothing: antialiased;
         background-color: #fff;
         font-size: 16px;
@@ -99,31 +115,43 @@ export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
     </header>
     <main id="main"></main>
     <footer>
-	<!--
+      <!--
       <button id="dl-button">Download data as JSON</button>
       <div class="spacer"></div>
       <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
        -->
     </footer>
 
-    <script src="https://cdn.plot.ly/plotly-3.0.0.min.js" charset="utf-8"></script>
+    <script
+      src="https://cdn.plot.ly/plotly-3.0.0.min.js"
+      charset="utf-8"
+    ></script>
     <script src="data.js"></script>
     <script id="main-script">
-      'use strict';
-      (function() {
-        
-	// Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+      "use strict";
+      (function () {
+        // Colors from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
         const colors = [
-	  '#dea584', '#00add8', '#f1e05a', '#000080', '#3572a5',
-	  '#f34b7d', '#f34b7d', '#a270ba', '#b07219', '#178600',
-	  '#38ff38', '#ff3838', '#333333',
-	];
+          "#dea584",
+          "#00add8",
+          "#f1e05a",
+          "#000080",
+          "#3572a5",
+          "#f34b7d",
+          "#f34b7d",
+          "#a270ba",
+          "#b07219",
+          "#178600",
+          "#38ff38",
+          "#ff3838",
+          "#333333",
+        ];
 
         function init() {
           function collectBenchesPerTestCase(entries) {
             const map = new Map();
             for (const entry of entries) {
-              const {commit, date, tool, benches} = entry;
+              const { commit, date, tool, benches } = entry;
               for (const bench of benches) {
                 const result = { commit, date, tool, bench };
                 const arr = map.get(bench.name);
@@ -140,62 +168,60 @@ export const DEFAULT_INDEX_HTML = String.raw`<!DOCTYPE html>
           const data = window.BENCHMARK_DATA;
 
           // Render header
-          document.getElementById('last-update').textContent = new Date(data.lastUpdate).toString();
-          const repoLink = document.getElementById('repository-link');
+          document.getElementById("last-update").textContent = new Date(
+            data.lastUpdate,
+          ).toString();
+          const repoLink = document.getElementById("repository-link");
           repoLink.href = data.repoUrl;
           repoLink.textContent = data.repoUrl;
 
           // Prepare data points for charts
-          return Object.keys(data.entries).map(name => ({
+          return Object.keys(data.entries).map((name) => ({
             name,
             dataSet: collectBenchesPerTestCase(data.entries[name]),
           }));
         }
 
-	// input: separated-out datasets
+        // input: separated-out datasets
         function renderAllCharts(dataSets) {
-
           function renderGraph(parent, dataSets) {
+            const datasets = Array.from(
+              dataSets.dataSet.entries().map(([name, dataset], index) => {
+                return {
+                  name: name,
+                  y: dataset.map((d) => d.bench.value),
+                };
+              }),
+            );
 
-
-	    const datasets = Array.from(dataSets.dataSet.entries().map(([name, dataset], index) => {
-
-		return {
-			name: name,
-			y: dataset.map(d => d.bench.value),
-		};
-	    }));
-
-            const canvas = document.createElement('canvas');
-            canvas.className = 'benchmark-chart';
+            const canvas = document.createElement("canvas");
+            canvas.className = "benchmark-chart";
             parent.appendChild(canvas);
-             
-	    // TODO: more config
-	    const layout = {
-	      width: 1200,
-	      height: 600
 
-	    };
+            // TODO: more config
+            const layout = {
+              width: 1200,
+              height: 600,
+            };
 
-	    const plot = Plotly.newPlot(parent, datasets, layout);
+            const plot = Plotly.newPlot(parent, datasets, layout);
           }
 
-          const main = document.getElementById('main');
-	  const setElem = document.createElement('div');
-	  setElem.className = 'benchmark-set';
-	  main.appendChild(setElem);
+          const main = document.getElementById("main");
+          const setElem = document.createElement("div");
+          setElem.className = "benchmark-set";
+          main.appendChild(setElem);
 
-	  const nameElem = document.createElement('h1');
-	  nameElem.className = 'benchmark-title';
-	  nameElem.textContent = 'All benchmarks';
-	  setElem.appendChild(nameElem);
+          const nameElem = document.createElement("h1");
+          nameElem.className = "benchmark-title";
+          nameElem.textContent = "All benchmarks";
+          setElem.appendChild(nameElem);
 
-	  const graphsElem = document.createElement('div');
-	  graphsElem.className = 'benchmark-graphs';
-	  setElem.appendChild(graphsElem);
+          const graphsElem = document.createElement("div");
+          graphsElem.className = "benchmark-graphs";
+          setElem.appendChild(graphsElem);
 
-	  renderGraph(graphsElem, dataSets[0]);
-
+          renderGraph(graphsElem, dataSets[0]);
         }
 
         renderAllCharts(init()); // Start

--- a/src/default_index_html.ts
+++ b/src/default_index_html.ts
@@ -1,0 +1,2 @@
+import * as fs from 'fs';
+export const DEFAULT_INDEX_HTML = fs.readFileSync('src/default_index.html', 'utf-8');


### PR DESCRIPTION
A new benchmark plotting interface for GitHub Pages, including multiple possibilities for filtered/organized plots.

Add plots by:
For each (os, key size): (name/api/platform)
 - e.g. KeyGen incremental neon

Also, because the default `index.html` has become more complex and itself includes JS template strings, the `index.html` is no longer included as a `String.raw` (which was causing the template strings to be misinterpreted), and is now included as a separate file whose contents are loaded.

Additionally, the `index.html` in this PR currently assumes that the benchmark name provided by the `cargo bench` output is in a certain, fixed format. This metadata is provided to the Action directly.