### PR TITLE
Fix `prepare-release` script to also include the `dist/src/comment` directory

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -63,7 +63,7 @@ mv .release/dist/src/ ./dist/
 mv .release/*.json .
 mv .release/node_modules .
 
-git add action.yml action-types.yml ./dist/src/*.js package.json package-lock.json node_modules
+git add action.yml action-types.yml ./dist/src/*.js ./dist/src/comment/*.js package.json package-lock.json node_modules
 set +x
 
 echo "Done. Please check 'git diff --cached' to verify changes. If ok, add version tag and push it to remote"


### PR DESCRIPTION
This PR updates `prepare-release.sh` to also include the `.js` files in `dist/src/comment` .