### PR TITLE
Add error handling for retrieving whether the current repo is private

### DIFF
--- a/src/write.ts
+++ b/src/write.ts
@@ -355,7 +355,7 @@ async function writeBenchmarkToGitHubPagesWithRetry(
     // on the merge queue (which is a known bug).
     // TODO: identify which of the below cases are needed. Potentially always
     // require the gh-repository field.
-    let isPrivateRepo = false;
+    let isPrivateRepo = null;
     try {
         isPrivateRepo = github.context.payload.repository?.private ?? false;
     } catch (error) {
@@ -377,9 +377,9 @@ async function writeBenchmarkToGitHubPagesWithRetry(
         });
         extraGitArguments = [`--work-tree=${benchmarkBaseDir}`, `--git-dir=${benchmarkBaseDir}/.git`];
         await git.checkout(ghPagesBranch, extraGitArguments);
-    } else if (!skipFetchGhPages && (!isPrivateRepo || githubToken)) {
+    } else if (!skipFetchGhPages && (isPrivateRepo === false || githubToken)) {
         await git.pull(githubToken, ghPagesBranch);
-    } else if (isPrivateRepo && !skipFetchGhPages) {
+    } else if (isPrivateRepo === true && !skipFetchGhPages) {
         core.warning(
             "'git pull' was skipped. If you want to ensure GitHub Pages branch is up-to-date " +
                 "before generating a commit, please set 'github-token' input to pull GitHub pages branch",

--- a/src/write.ts
+++ b/src/write.ts
@@ -351,7 +351,10 @@ async function writeBenchmarkToGitHubPagesWithRetry(
     } = config;
     const rollbackActions = new Array<() => Promise<void>>();
 
-    // FIXME: This payload is not available on `schedule:` or `workflow_dispatch:` events.
+    // XXX: fix that ensures we don't fail if the current branch is not available
+    // on the merge queue (which is a known bug).
+    // TODO: identify which of the below cases are needed. Potentially always
+    // require the gh-repository field.
     let isPrivateRepo = false;
     try {
         isPrivateRepo = github.context.payload.repository?.private ?? false;


### PR DESCRIPTION
Fix bug on the merge queue:
 - The line that checks whether the current repo (not the one specified in `ghRepository`) is private may fail, due to the current branch not being accessible from the merge queue.
 - This PR adds some error handling to this line. 
 - In the future, we will also want to assess whether to accept any case where the `ghRepository` is unset. In that case,  `isPrivateRepo` will not need to be determined here.