### PR TITLE
fix time zone

### DIFF
--- a/src/default_index.html
+++ b/src/default_index.html
@@ -212,7 +212,7 @@
                                     keySize,
                                     os,
                                     platform,
-                                    x: dataset.map((d) => d.commit.timestamp),
+                                    x: dataset.map((d) => new Date(d.commit.timestamp)),
                                     y: dataset.map((d) => d.bench.value),
                                     dataset,
                                     showlegend: true,


### PR DESCRIPTION
Fixes a bug where the date on the x axis of the graphs was not displayed with the correct time zone.