### PR TITLE
print stack trace to stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,14 @@ async function main() {
     console.log('github-action-benchmark was run successfully!', '\nData:', bench);
 }
 
-function stackTrace(e: Error): string {
-    // get the stack trace without the error message
-    const stackTrace = String(e.stack).split('\n').slice(1).join('\n');
-
-    return `Stack trace:\n${stackTrace}`;
-}
-
 main().catch((e) => {
+    function stackTrace(e: Error): string {
+        const prefix = 'Error: ' + e.message;
+        // get the stack trace without the error message
+        const stackTrace = String(e.stack).replace(prefix, '');
+
+        return 'Stack trace:' + stackTrace;
+    }
     console.log(stackTrace(e));
 
     core.setFailed(e.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,8 @@ async function main() {
     console.log('github-action-benchmark was run successfully!', '\nData:', bench);
 }
 
-main().catch((e) => core.setFailed(e.message));
+main().catch((e) => {
+    console.log(e.stack);
+
+    core.setFailed(e.message);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ async function main() {
 }
 
 function stackTrace(e: Error): String {
-    // print the stack trace without the error message
+    // get the stack trace without the error message
     let stackTrace = String(e.stack).split('\n').slice(1).join('\n');
 
     return `Stack trace:\n${stackTrace}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,15 @@ async function main() {
     console.log('github-action-benchmark was run successfully!', '\nData:', bench);
 }
 
+function stackTrace(e: Error): String {
+    // print the stack trace without the error message
+    let stackTrace = String(e.stack).split('\n').slice(1).join('\n');
+
+    return `Stack trace:\n${stackTrace}`;
+}
+
 main().catch((e) => {
-    console.log(e.stack);
+    console.log(stackTrace(e));
 
     core.setFailed(e.message);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,9 @@ main().catch((e) => {
     function stackTrace(e: Error): string {
         const prefix = 'Error: ' + e.message;
         // get the stack trace without the error message
-        const stackTrace = String(e.stack).replace(prefix, '');
+        const stackTrace = String(e.stack).replace(prefix, 'Stack trace:');
 
-        return 'Stack trace:' + stackTrace;
+        return stackTrace;
     }
     console.log(stackTrace(e));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,9 @@ async function main() {
     console.log('github-action-benchmark was run successfully!', '\nData:', bench);
 }
 
-function stackTrace(e: Error): String {
+function stackTrace(e: Error): string {
     // get the stack trace without the error message
-    let stackTrace = String(e.stack).split('\n').slice(1).join('\n');
+    const stackTrace = String(e.stack).split('\n').slice(1).join('\n');
 
     return `Stack trace:\n${stackTrace}`;
 }


### PR DESCRIPTION
This PR modifies the error handling for `main()` to additionally print out a stack trace, instead of just the error's `Message`. 