### PR TITLE
Check merge_group webhook event for head_commit

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -106,6 +106,12 @@ async function getCommit(githubToken?: string, ref?: string): Promise<Commit> {
         return github.context.payload.head_commit;
     }
 
+    // also try with merge group
+    if (github.context.payload.merge_group.head_commit) {
+	return github.context.payload.merge_group.head_commit;
+    }
+
+
     const pr = github.context.payload.pull_request;
 
     if (pr) {

--- a/src/load.ts
+++ b/src/load.ts
@@ -107,10 +107,13 @@ async function getCommit(githubToken?: string, ref?: string): Promise<Commit> {
     }
 
     // also try with merge group
-    if (github.context.payload.merge_group.head_commit) {
-	return github.context.payload.merge_group.head_commit;
-    }
+    const mergeGroup = github.context.payload.merge_group;
 
+    if (mergeGroup) {
+        if (mergeGroup.head_commit) {
+            return mergeGroup.head_commit;
+        }
+    }
 
     const pr = github.context.payload.pull_request;
 


### PR DESCRIPTION
This PR attempts to retrieve the `head_commit` from the `merge_group` webhook event data, if available.

More details on this webhook event here:
https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group