### PR TITLE
FIX: construct URL on merge queue

### DIFF
--- a/src/load.ts
+++ b/src/load.ts
@@ -32,7 +32,7 @@ interface Commit {
     message: string;
     timestamp?: string;
     tree_id?: unknown; // Unused
-    url?: unknown
+    url: string;
 }
 
 interface PullRequest {
@@ -111,7 +111,13 @@ async function getCommit(githubToken?: string, ref?: string): Promise<Commit> {
 
     if (mergeGroup) {
         if (mergeGroup.head_commit) {
-            return mergeGroup.head_commit;
+            const commit = mergeGroup.head_commit;
+            // XXX: only supports github.com for now,
+            // since this information is not currently available
+            // in the merge group webhook payload.
+            commit.url = `https://github.com/${mergeGroup.organization}/${mergeGroup.repository}/commits/${commit.id}`;
+
+	    return commit;
         }
     }
 

--- a/src/load.ts
+++ b/src/load.ts
@@ -32,7 +32,7 @@ interface Commit {
     message: string;
     timestamp?: string;
     tree_id?: unknown; // Unused
-    url?: string;
+    url?: unknown
 }
 
 interface PullRequest {

--- a/src/load.ts
+++ b/src/load.ts
@@ -32,7 +32,7 @@ interface Commit {
     message: string;
     timestamp?: string;
     tree_id?: unknown; // Unused
-    url: string;
+    url?: string;
 }
 
 interface PullRequest {


### PR DESCRIPTION
This PR constructs the URL for the `head_commit` on the merge queue (since it is not available directly)