### PR TITLE
Generic charts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,3 +36,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages-test
+          group-by: ['os', 'keySize']

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,4 +36,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages-test
-          group-by: "['os', 'keySize']"
+          group-by: 'os,keySize'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,4 +36,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages-test
-          group-by: ['os', 'keySize']
+          group-by: "['os', 'keySize']"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ branch and/or alert commit comment.
 
 Input definitions are written in [action.yml](./action.yml).
 
+#### `group-by` (Required)
+- Type: String
+- Default: `'["os"]'`
+
+The grouping logic for the charts. This field specifies which data fields to group the charts by.
+
 #### `name` (Required)
 
 - Type: String

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Input definitions are written in [action.yml](./action.yml).
 
 #### `group-by` (Required)
 - Type: String
-- Default: `'["os"]'`
+- Default: `"os"`
 
 The grouping logic for the charts. This field specifies which data fields to group the charts by.
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,4 +1,6 @@
 inputs:
+  group-by:
+    type: string
   name:
     type: string
   input-data-path:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: 'blue'
 
 inputs:
+  group-by:
+    description: 'Groups for plots. This value must be a comma-separated list'
+    required: true
+    default: 'os'
   name:
     description: 'Name of the benchmark. This value must be identical among all benchmarks'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   group-by:
-    description: 'Groups for plots. This value must be a comma-separated list'
+    description: 'Groups for plots. This value must be an array of strings'
     required: true
-    default: 'os'
+    default: '["os"]'
   name:
     description: 'Name of the benchmark. This value must be identical among all benchmarks'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   group-by:
     description: 'Groups for plots. This value must be an array of strings'
     required: true
-    default: '["os"]'
+    default: 'os'
   name:
     description: 'Name of the benchmark. This value must be identical among all benchmarks'
     required: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -187,12 +187,22 @@ function validateMaxItemsInChart(max: number | null) {
 }
 
 function validateGroupBy(groupBy: string | undefined): string[] {
+    const defaultValue: string[] = ['os'];
     if (groupBy === undefined) {
-        // default
-        return ['os'];
+        return defaultValue;
     }
-    // TODO: more validation
-    return JSON.parse(groupBy.replaceAll("'", '"'));
+
+    let arr: string[];
+    try {
+        arr = JSON.parse(groupBy.replaceAll("'", '"'));
+    } catch (e) {
+        // default
+        return defaultValue;
+    }
+    if (!Array.isArray(arr)) {
+        return defaultValue;
+    }
+    return arr;
 }
 
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {

--- a/src/config.ts
+++ b/src/config.ts
@@ -193,7 +193,7 @@ function validateGroupBy(groupBy?: string): string[] {
 
     const keys = groupBy.split(',');
 
-    if (keys.length === 0) {
+    if (keys.length === 1 && keys[0] === "") {
         return ['os'];
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 export interface Config {
     name: string;
+    groupBy: string[];
     biggerIsBetter: boolean;
     inputDataPath: string; // path to out data
     ghPagesBranch: string;
@@ -185,6 +186,15 @@ function validateMaxItemsInChart(max: number | null) {
     }
 }
 
+function validateGroupBy(groupBy: string | undefined): string[] {
+    if (groupBy === undefined) {
+        // default
+        return ['os'];
+    }
+    // TODO: more validation
+    return groupBy.split(',');
+}
+
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {
     if (alertThreshold === null) {
         throw new Error("'alert-threshold' input must not be empty");
@@ -197,6 +207,8 @@ function validateAlertThreshold(alertThreshold: number | null, failThreshold: nu
 }
 
 export async function configFromJobInput(): Promise<Config> {
+    const groupByString: string | undefined = core.getInput('group-by') || undefined;
+
     let inputDataPath: string = core.getInput('input-data-path');
     const biggerIsBetter = getBoolInput('bigger-is-better');
     const ghPagesBranch: string = core.getInput('gh-pages-branch');
@@ -218,6 +230,7 @@ export async function configFromJobInput(): Promise<Config> {
     const maxItemsInChart = getUintInput('max-items-in-chart');
     let failThreshold = getPercentageInput('fail-threshold');
 
+    const groupBy = validateGroupBy(groupByString);
     inputDataPath = await validateInputDataPath(inputDataPath);
     validateGhPagesBranch(ghPagesBranch);
     benchmarkDataDirPath = validateBenchmarkDataDirPath(benchmarkDataDirPath);
@@ -243,6 +256,7 @@ export async function configFromJobInput(): Promise<Config> {
     }
 
     return {
+        groupBy,
         name,
         biggerIsBetter,
         inputDataPath,

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,7 +192,7 @@ function validateGroupBy(groupBy: string | undefined): string[] {
         return ['os'];
     }
     // TODO: more validation
-    return JSON.parse(groupBy.replaceAll("'", "\""));
+    return JSON.parse(groupBy.replaceAll("'", '"'));
 }
 
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {

--- a/src/config.ts
+++ b/src/config.ts
@@ -191,7 +191,13 @@ function validateGroupBy(groupBy?: string): string[] {
         return ['os'];
     }
 
-    return groupBy.split(',');
+    const keys = groupBy.split(',');
+
+    if (keys.length === 0) {
+        return ['os'];
+    }
+
+    return keys;
 }
 
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {

--- a/src/config.ts
+++ b/src/config.ts
@@ -186,23 +186,12 @@ function validateMaxItemsInChart(max: number | null) {
     }
 }
 
-function validateGroupBy(groupBy: string | undefined): string[] {
-    const defaultValue: string[] = ['os'];
+function validateGroupBy(groupBy?: string): string[] {
     if (groupBy === undefined) {
-        return defaultValue;
+        return ['os'];
     }
 
-    let arr: string[];
-    try {
-        arr = JSON.parse(groupBy.replaceAll("'", '"'));
-    } catch (e) {
-        // default
-        return defaultValue;
-    }
-    if (!Array.isArray(arr)) {
-        return defaultValue;
-    }
-    return arr;
+    return groupBy.split(',');
 }
 
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,7 +192,7 @@ function validateGroupBy(groupBy: string | undefined): string[] {
         return ['os'];
     }
     // TODO: more validation
-    return groupBy.split(',');
+    return JSON.parse(groupBy.replaceAll("'", "\""));
 }
 
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -293,7 +293,11 @@
 
                     const [datasets, layout] = buildPlotConfig(dataSets[0]);
 
-                    const groupBy = window.BENCHMARK_DATA.groupBy;
+                    let groupBy = window.BENCHMARK_DATA.groupBy;
+                    if (!groupBy || typeof groupBy !== 'object') {
+                        console.error('No or invalid groupBy provided: defaulting to `[os]`');
+                        groupBy = ['os'];
+                    }
                     createPlotsGroupBy(setElem, groupBy, datasets, layout);
                 }
 

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -181,8 +181,7 @@
                             // TODO:
                             const filter = {};
                             for (let key of groupBy) {
-                                const value = d[key];
-                                filter[key] = value;
+                                filter[key] = d.metadata[key];
                             }
                             return JSON.stringify(filter);
                         });
@@ -190,27 +189,33 @@
                         let data = Object.entries(groupedData);
 
                         for (let [key, value] of data) {
+                            // skip empty key
+                            if (key === '{}') {
+                                continue;
+                            }
                             // unparse the groupBy keys
-                            let filter = JSON.parse(key);
+                            let group = JSON.parse(key);
                             const graphsElem = document.createElement('div');
                             graphsElem.className = 'benchmark-graphs';
                             parent.appendChild(graphsElem);
-                            chartByOsAndKeySize(graphsElem, filter.os, filter.keySize, datasets, layout);
+                            chartByGroup(graphsElem, group, datasets, layout);
                         }
                     }
-                    function chartByOsAndKeySize(parent, os, keySize, datasets, layout) {
+                    function chartByGroup(parent, group, datasets, layout) {
                         const filtered = Array.from(
                             datasets
-                                .filter(
-                                    (d) =>
-                                        d.os == os &&
-                                        d.keySize == keySize &&
-                                        d.name !== undefined &&
-                                        d.api !== undefined &&
-                                        d.platform !== undefined,
+                                .filter((d) =>
+                                    Object.keys(group).every(
+                                        (key) => d.metadata[key] === group[key] && d.metadata[key] !== undefined,
+                                    ),
                                 )
                                 .map((trace) => {
-                                    trace.name = `${trace.name} - ${trace.api} - ${trace.platform}`;
+                                    const name = Object.entries(trace.metadata)
+                                        .filter(([key, value]) => !Object.keys(group).includes(key) && key !== 'unit')
+                                        .map(([_k, v]) => v)
+                                        .filter((v) => v !== undefined)
+                                        .join(' ');
+                                    trace.name = name;
                                     // tooltip
                                     trace.text = trace.dataset.map(
                                         (d) =>
@@ -220,17 +225,20 @@
                                 }),
                         );
 
+                        const description = Object.entries(group)
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(', ');
                         // return if no datasets
                         if (filtered.length == 0) {
-                            console.log(`No datasets found with os "${os} and keySize ${keySize}"`);
+                            console.log(`No datasets found with ${description}`);
                             return;
                         }
                         // get the unit from the first item (all are same, since this field is part of the key in `collectBenchesPerTestCase()`)
                         // this is possible because there is at least one data point
-                        const unit = filtered[0].unit;
+                        const unit = filtered[0].metadata.unit;
 
                         // update layout
-                        layout.title = { text: `OS: ${os}, keySize: ${keySize}` };
+                        layout.title = { text: description };
                         layout.yaxis = { title: { text: `Value (${unit})` } };
 
                         // create plot
@@ -243,13 +251,15 @@
                                 let { name, api, keySize, category, os, platform, dataset, unit } = item;
 
                                 return {
-                                    category,
-                                    name,
-                                    api,
-                                    keySize,
-                                    os,
-                                    platform,
-                                    unit,
+                                    metadata: {
+                                        category,
+                                        name,
+                                        api,
+                                        keySize,
+                                        os,
+                                        platform,
+                                        unit,
+                                    },
                                     x: dataset.map((d) => new Date(d.commit.timestamp)),
                                     y: dataset.map((d) => d.bench.value),
                                     dataset,

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -171,14 +171,9 @@
                 // input: separated-out datasets
                 function renderAllCharts(dataSets) {
                     function createPlotsGroupBy(parent, groupBy, datasets, layout) {
-                        // TODO: need a plot for every non-null/NaN combo of values
-                        // TODO: filter out invalid keys
-                        // TODO: plot title
-
                         // group by (key1, key2, ...)
                         createTitle(parent, `Compare platform for ${groupBy}`);
                         const groupedData = Object.groupBy(datasets, (d) => {
-                            // TODO:
                             const filter = {};
                             for (let key of groupBy) {
                                 filter[key] = d.metadata[key];
@@ -276,7 +271,6 @@
                             .filter((s) => s.includes('GMT'))
                             .map((s) => `(${s})`);
 
-                        // TODO: more config
                         const layout = {
                             height: 600,
                             width: 1200,

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -170,6 +170,34 @@
 
                 // input: separated-out datasets
                 function renderAllCharts(dataSets) {
+                    function createPlotsGroupBy(parent, groupBy, datasets, layout) {
+                        // TODO: need a plot for every non-null/NaN combo of values
+                        // TODO: filter out invalid keys
+                        // TODO: plot title
+
+                        // group by (key1, key2, ...)
+                        createTitle(parent, `Compare platform for ${groupBy}`);
+                        const groupedData = Object.groupBy(datasets, (d) => {
+                            // TODO:
+                            const filter = {};
+                            for (let key of groupBy) {
+                                const value = d[key];
+                                filter[key] = value;
+                            }
+                            return JSON.stringify(filter);
+                        });
+
+                        let data = Object.entries(groupedData);
+
+                        for (let [key, value] of data) {
+                            // unparse the groupBy keys
+                            let filter = JSON.parse(key);
+                            const graphsElem = document.createElement('div');
+                            graphsElem.className = 'benchmark-graphs';
+                            parent.appendChild(graphsElem);
+                            chartByOsAndKeySize(graphsElem, filter.os, filter.keySize, datasets, layout);
+                        }
+                    }
                     function chartByOsAndKeySize(parent, os, keySize, datasets, layout) {
                         const filtered = Array.from(
                             datasets
@@ -255,23 +283,8 @@
 
                     const [datasets, layout] = buildPlotConfig(dataSets[0]);
 
-                    const osList = [...new Set(datasets.map((d) => d.os))];
-                    const keySizes = [...new Set(datasets.map((d) => d.keySize))];
-
-                    const _groupBy = window.BENCHMARK_DATA.groupBy;
-                    // TODO: use groupBy for splitting out plots
-                    // plots by OS/Key Size
-                    createTitle(setElem, 'Compare platform for OS/key size');
-                    for (let os of osList) {
-                        for (let keySize of keySizes) {
-                            if (!isNaN(keySize)) {
-                                const graphsElem = document.createElement('div');
-                                graphsElem.className = 'benchmark-graphs';
-                                setElem.appendChild(graphsElem);
-                                chartByOsAndKeySize(graphsElem, os, keySize, datasets, layout);
-                            }
-                        }
-                    }
+                    const groupBy = window.BENCHMARK_DATA.groupBy;
+                    createPlotsGroupBy(setElem, groupBy, datasets, layout);
                 }
 
                 renderAllCharts(init()); // Start

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -258,6 +258,8 @@
                     const osList = [...new Set(datasets.map((d) => d.os))];
                     const keySizes = [...new Set(datasets.map((d) => d.keySize))];
 
+                    const _groupBy = window.BENCHMARK_DATA.groupBy;
+                    // TODO: use groupBy for splitting out plots
                     // plots by OS/Key Size
                     createTitle(setElem, 'Compare platform for OS/key size');
                     for (let os of osList) {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -172,7 +172,11 @@
                 function renderAllCharts(dataSets) {
                     function createPlotsGroupBy(parent, groupBy, datasets, layout) {
                         // group by (key1, key2, ...)
+
+                        // create title
                         createTitle(parent, `Compare platform for ${groupBy}`);
+
+                        // group datasets by the relevant keys
                         const groupedData = Object.groupBy(datasets, (d) => {
                             const filter = {};
                             for (let key of groupBy) {
@@ -181,8 +185,8 @@
                             return JSON.stringify(filter);
                         });
 
+                        // create  a chart for each group
                         let data = Object.entries(groupedData);
-
                         for (let [key, value] of data) {
                             // skip empty key
                             if (key === '{}') {
@@ -196,22 +200,37 @@
                             chartByGroup(graphsElem, group, datasets, layout);
                         }
                     }
+                    function dataItemBelongsToGroup(d, groupBy) {
+                        // returns true if for every key in the groupBy entry,
+                        // the data item's value for that key (e.g. `os`: `windows_64`)
+                        // matches the value for this group.
+                        return Object.keys(group).every(
+                            (key) => d.metadata[key] === group[key] && d.metadata[key] !== undefined,
+                        );
+                    }
+                    function getOtherMetadataEntries(d, groupBy) {
+                        // returns the metadata keys that are not already
+                        // taken into account by the filter
+                        // and are not the unit key
+                        return Object.entries(d.metadata).filter(
+                            ([key, value]) => !Object.keys(groupBy).includes(key) && key !== 'unit',
+                        );
+                    }
                     function chartByGroup(parent, group, datasets, layout) {
                         const filtered = Array.from(
                             datasets
-                                .filter((d) =>
-                                    Object.keys(group).every(
-                                        (key) => d.metadata[key] === group[key] && d.metadata[key] !== undefined,
-                                    ),
-                                )
+                                .filter((d) => dataItemBelongsToGroup(d, group))
                                 .map((trace) => {
-                                    const name = Object.entries(trace.metadata)
-                                        .filter(([key, value]) => !Object.keys(group).includes(key) && key !== 'unit')
+                                    // set the name in the legend
+                                    // construct the name using the other metadata keys
+                                    // that were not taken into account by the filter
+                                    const otherEntries = getOtherMetadataEntries(trace, groupBy);
+                                    trace.name = otherEntries
                                         .map(([_k, v]) => v)
                                         .filter((v) => v !== undefined)
                                         .join(' ');
-                                    trace.name = name;
-                                    // tooltip
+
+                                    // set the tooltip text
                                     trace.text = trace.dataset.map(
                                         (d) =>
                                             `<b>${trace.name}</b><br>value: ${d.bench.value} ${d.bench.unit} ${d.bench.range}<br>commit id: ${d.commit.id}<br>commit name: ${d.commit.message}<br>commit url: ${d.commit.url}`,

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -183,6 +183,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
     describe('with external json file', function () {
         const dataJson = 'data.json';
         const defaultCfg: Config = {
+            groupBy: ['os'],
             name: 'Test benchmark',
             biggerIsBetter: false,
             inputDataPath: 'dummy', // Should not affect
@@ -235,6 +236,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'appends new result to existing data',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -271,6 +273,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'creates new result suite to existing data file',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -295,6 +298,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'appends new result to existing multiple benchmarks data',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -327,6 +331,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'raises an alert when exceeding threshold 2.0',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -366,6 +371,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'raises an alert with tool whose result value is bigger-is-better',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -404,6 +410,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'raises an alert without benchmark name with default benchmark name',
                 config: { ...defaultCfg, name: 'Benchmark' },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -442,6 +449,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'raises an alert without CC names',
                 config: { ...defaultCfg, alertCommentCcUsers: [] },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -478,6 +486,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'sends commit comment on alert with GitHub API',
                 config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -503,6 +512,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'does not raise an alert when both comment-on-alert and fail-on-alert are disabled',
                 config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -529,6 +539,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'ignores other bench case on detecting alerts',
                 config: defaultCfg,
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -555,6 +566,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'throws an error when GitHub token is not set (though this case should not happen in favor of validation)',
                 config: { ...defaultCfg, commentOnAlert: true },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -581,6 +593,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'truncates data items if it exceeds max-items-in-chart',
                 config: { ...defaultCfg, maxItemsInChart: 1 },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -622,6 +635,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'changes title when threshold is zero which means comment always happens',
                 config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -660,6 +674,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'raises an alert with different failure threshold from alert threshold',
                 config: { ...defaultCfg, failThreshold: 3 },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -700,6 +715,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 it: 'does not raise an alert when not exceeding failure threshold',
                 config: { ...defaultCfg, failThreshold: 3 },
                 data: {
+                    groupBy: ['os'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -881,6 +897,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
         }
 
         const defaultCfg: Config = {
+            groupBy: ['os'],
             name: 'Test benchmark',
             biggerIsBetter: false,
             inputDataPath: 'dummy', // Should not affect


### PR DESCRIPTION
This pull request updates the action to add a `group-by` field to the action config. This field allows the user of the action to specify how to group the charts (e.g. by `os`, `keySize`).