### PR TITLE
Refactor chart creation script

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,3 +37,4 @@ jobs:
           auto-push: true
           gh-pages-branch: gh-pages-test
           group-by: 'os,keySize'
+          schema: 'os,keySize,name,platform,api,category'

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Input definitions are written in [action.yml](./action.yml).
 - Default: `"os"`
 
 The grouping logic for the charts. This field specifies which data fields to group the charts by.
+ 
+### `schema` (Required)
+- Type: String
+- Default: `"name,platform,os,keySize,api,category"`
+
+The metadata schema for plots. This value must be a comma-separated list of strings.
 
 #### `name` (Required)
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,6 +1,8 @@
 inputs:
   group-by:
     type: string
+  schema:
+    type: string
   name:
     type: string
   input-data-path:

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,13 @@ branding:
 
 inputs:
   group-by:
-    description: 'Groups for plots. This value must be an array of strings'
+    description: 'Groups for plots. This value must be a comma-separated list of strings'
     required: true
     default: 'os'
+  schema:
+    description: 'Metadata schema for plots. This value must be a comma-separated list of strings'
+    required: true
+    default: 'name,platform,os,keySize,api,category'
   name:
     description: 'Name of the benchmark. This value must be identical among all benchmarks'
     required: true

--- a/src/config.ts
+++ b/src/config.ts
@@ -229,7 +229,7 @@ function validateAlertThreshold(alertThreshold: number | null, failThreshold: nu
 
 export async function configFromJobInput(): Promise<Config> {
     const groupByString: string | undefined = core.getInput('group-by') || undefined;
-    const schemaString: string = core.getInput('schema');
+    const schemaString: string | undefined = core.getInput('schema') || undefined;
 
     let inputDataPath: string = core.getInput('input-data-path');
     const biggerIsBetter = getBoolInput('bigger-is-better');

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 export interface Config {
     name: string;
     groupBy: string[];
+    schema: string[];
     biggerIsBetter: boolean;
     inputDataPath: string; // path to out data
     ghPagesBranch: string;
@@ -200,6 +201,21 @@ function validateGroupBy(groupBy?: string): string[] {
     return keys;
 }
 
+function validateSchema(schema?: string): string[] {
+    const defaultSchema = ['name', 'platform', 'os', 'keySize', 'api', 'category'];
+    if (schema === undefined) {
+        return defaultSchema;
+    }
+
+    const keys = schema.split(',');
+
+    if (keys.length === 1 && keys[0] === '') {
+        return defaultSchema;
+    }
+
+    return keys;
+}
+
 function validateAlertThreshold(alertThreshold: number | null, failThreshold: number | null): asserts alertThreshold {
     if (alertThreshold === null) {
         throw new Error("'alert-threshold' input must not be empty");
@@ -213,6 +229,7 @@ function validateAlertThreshold(alertThreshold: number | null, failThreshold: nu
 
 export async function configFromJobInput(): Promise<Config> {
     const groupByString: string | undefined = core.getInput('group-by') || undefined;
+    const schemaString: string = core.getInput('schema');
 
     let inputDataPath: string = core.getInput('input-data-path');
     const biggerIsBetter = getBoolInput('bigger-is-better');
@@ -236,6 +253,7 @@ export async function configFromJobInput(): Promise<Config> {
     let failThreshold = getPercentageInput('fail-threshold');
 
     const groupBy = validateGroupBy(groupByString);
+    const schema = validateSchema(schemaString);
     inputDataPath = await validateInputDataPath(inputDataPath);
     validateGhPagesBranch(ghPagesBranch);
     benchmarkDataDirPath = validateBenchmarkDataDirPath(benchmarkDataDirPath);
@@ -261,6 +279,7 @@ export async function configFromJobInput(): Promise<Config> {
     }
 
     return {
+        schema,
         groupBy,
         name,
         biggerIsBetter,

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -109,43 +109,212 @@
         <script id="main-script">
             'use strict';
             (function () {
-                function init() {
-                    function collectBenchesPerTestCase(entries) {
-                        // TODO: collect by all fields in `bench`
-                        // collect in nested map
-                        const map = new Map();
-                        for (const entry of entries) {
-                            const { commit, date, benches } = entry;
-                            for (const bench of benches) {
-                                let name = bench.name;
-                                let platform = bench.platform;
-                                let os = bench.os;
-                                let keySize = bench.keySize;
-                                let api = bench.api;
-                                let category = bench.category;
-                                let unit = bench.unit;
+                function buildPlotLayout() {
+                    const offset = timeZoneOffset();
+                    const layout = {
+                        height: 600,
+                        width: 1200,
+                        xaxis: { title: { text: `Time of benchmark run ${offset}` }, type: 'date' },
+                    };
 
-                                let key = JSON.stringify({ name, platform, os, keySize, api, category, unit });
-                                const result = { commit, date, bench };
+                    return layout;
+                }
 
-                                const arr = map.get(key);
-                                if (arr === undefined) {
-                                    map.set(key, [result]);
-                                } else {
-                                    arr.push(result);
-                                }
-                            }
-                        }
-
-                        // replace the key with data
-                        const data = Array.from(map.entries()).map(([key, value]) => {
-                            const d = JSON.parse(key);
-                            d.dataset = value;
-                            return d;
-                        });
-                        return data;
+                function addTitleToElement(parent, title) {
+                    const titleElem = document.createElement('h1');
+                    titleElem.className = 'benchmark-title';
+                    titleElem.textContent = title;
+                    parent.appendChild(titleElem);
+                }
+                function chartFilteredTraces(parent, title, filteredTraces) {
+                    // return if no datasets
+                    if (filteredTraces.length == 0) {
+                        console.log(`No datasets found with ${description}`);
+                        return;
                     }
 
+                    // create elem for plot
+                    const elem = document.createElement('div');
+                    elem.className = 'benchmark-graphs';
+                    parent.appendChild(elem);
+
+                    const layout = buildPlotLayout();
+
+                    // get the unit from the first item
+                    // (all are same, since this field is part of the key in `collectBenchesPerTestCase()`)
+                    // this is possible because there is at least one data point
+                    const unit = filteredTraces[0].metadata.unit;
+                    layout.yaxis = { title: { text: `Value (${unit})` } };
+
+                    layout.title = { text: title };
+
+                    // add the plot to the elem
+                    Plotly.newPlot(elem, filteredTraces, layout);
+                }
+
+                function timeZoneOffset() {
+                    // extract GMT+offset from current time zone, if available
+                    return new Date()
+                        .toString()
+                        .split(' ')
+                        .filter((s) => s.includes('GMT'))
+                        .map((s) => `(${s})`);
+                }
+
+                function buildKey(benchItem, schema) {
+                    // build the key from the values in the schema
+                    let key = {};
+                    for (const s of schema) {
+                        key[s] = benchItem[s];
+                    }
+                    return JSON.stringify(key);
+                }
+                function parseKey(keyString, schema) {
+                    const key = JSON.parse(keyString);
+                    for (const s of schema) {
+                        if (!key.hasOwnProperty(s)) {
+                            key[s] = undefined;
+                        }
+                    }
+                    return key;
+                }
+                // separates the data into traces by key
+                function separateAllTraces(commits, schema) {
+                    // flatten and keep commit data
+                    const data = commits
+                        .map((commitEntry) => {
+                            const { commit, date, benches } = commitEntry;
+                            return benches.map((bench) => {
+                                return { commit, date, bench };
+                            });
+                        })
+                        .flat();
+
+                    // group by key
+                    const groupedData = Object.groupBy(data, (benchEntry) => {
+                        return buildKey(benchEntry.bench, schema);
+                    });
+
+                    // prepare for plotting
+                    const traces = Object.entries(groupedData).map(([keyString, dataset]) => {
+                        const metadata = parseKey(keyString, schema);
+
+                        return {
+                            metadata,
+                            x: dataset.map((d) => new Date(d.commit.timestamp)),
+                            y: dataset.map((d) => d.bench.value),
+                            dataset,
+                            showlegend: true,
+                            hoverinfo: 'text',
+                        };
+                    });
+
+                    return Array.from(traces);
+                }
+                function retrieveGroupBy() {
+                    // get the groupBy object from `window.BENCHMARK_DATA`,
+                    // and return a default value if invalid or none is provided.
+
+                    let groupBy = window.BENCHMARK_DATA.groupBy;
+                    if (!groupBy || typeof groupBy !== 'object') {
+                        console.error('No or invalid groupBy provided: defaulting to `[os]`');
+                        groupBy = ['os'];
+                    }
+                    return groupBy;
+                }
+
+                function buildTraceGroupKey(trace, groupBy) {
+                    // build the groupKey for a trace,
+                    // which consists of the key-value pairs
+                    // for the groupBy keys only.
+                    const traceGroup = {};
+                    for (let key of groupBy) {
+                        traceGroup[key] = trace.metadata[key];
+                    }
+                    return JSON.stringify(traceGroup);
+                }
+                function getObservationTooltipText(name, observation) {
+                    const value = observation.bench.value;
+                    const unit = observation.bench.unit;
+                    const range = observation.bench.range;
+                    const commitId = observation.commit.id;
+                    const message = observation.commit.message;
+                    const url = observation.commit.url;
+
+                    return `<b>${name}</b><br>value: ${value} ${unit} ${range}<br>commit id: ${commitId}<br>commit name: ${message}<br>commit url: ${url}`;
+                }
+                function getLegendName(trace, groupBy, schema) {
+                    // return the name for the graph legend,
+                    // using only the metadata entries that are not included in the
+                    // groupBy, and are not 'unit'.
+                    // also, don't include the fields whose values are `undefined` in the name.
+
+                    // entries sorted by schema
+                    const orderedEntries = schema.map((key) => [key, trace.metadata[key]]);
+
+                    return orderedEntries
+                        .filter(([key, value]) => !groupBy.includes(key) && key !== 'unit' && value !== undefined)
+                        .map(([_, value]) => value)
+                        .join(' ');
+                }
+                function addLegendNameAndTooltip(trace, groupBy, schema) {
+                    // set the name in the legend
+                    trace.name = getLegendName(trace, groupBy, schema);
+
+                    // set the tooltip text
+                    trace.text = trace.dataset.map((observation) => getObservationTooltipText(trace.name, observation));
+                }
+
+                function buildTitleFromGroupKey(groupKey, groupBy) {
+                    // Display the fields in the group as a comma-separated list
+                    return groupBy
+                        .map((field) => [field, groupKey[field]])
+                        .map(([field, value]) => `${field}: ${value}`)
+                        .join(', ');
+                }
+                function renderAllCharts() {
+                    // retrieve the data for the benchmark with the first name
+                    // TODO: don't just support a single overarching name
+                    const entries = window.BENCHMARK_DATA.entries;
+                    const entry = Object.values(entries)[0];
+
+                    // build the data traces by separating out the observations
+                    // by key. This is equivalent to separating out the observations
+                    // by benchmark id, except that the benchmark id consists
+                    // of multiple, separate fields.
+                    // TODO: allow the user to specify the schema.
+                    const schema = ['name', 'platform', 'os', 'keySize', 'api', 'category', 'unit'];
+                    const traces = separateAllTraces(entry, schema);
+
+                    // get the groupBy information from `window.BENCHMARK_DATA`
+                    // this is an array of keys, e.g. ['os', 'keySize']
+                    // there should be one plot per combination of these values
+                    const groupBy = retrieveGroupBy();
+
+                    // create a div for the benchmark set
+                    const main = document.getElementById('main');
+                    const setElem = document.createElement('div');
+                    setElem.className = 'benchmark-set';
+                    main.appendChild(setElem);
+                    addTitleToElement(setElem, `Compare platform for ${groupBy}`);
+
+                    // group datasets by the relevant keys
+                    const groupedData = Object.groupBy(traces, (trace) => buildTraceGroupKey(trace, groupBy));
+
+                    // create  a chart for each group
+                    Object.entries(groupedData).forEach(([groupKeyString, filteredTraces]) => {
+                        // build the title
+                        const groupKey = parseKey(groupKeyString, groupBy);
+                        const title = buildTitleFromGroupKey(groupKey, groupBy);
+
+                        // add the legend name to each trace,
+                        // as well as the tooltip text for each point in each trace
+                        filteredTraces.forEach((trace) => addLegendNameAndTooltip(trace, groupBy, schema));
+
+                        chartFilteredTraces(setElem, title, filteredTraces);
+                    });
+                }
+                function init() {
                     const data = window.BENCHMARK_DATA;
 
                     // Render header
@@ -153,168 +322,10 @@
                     const repoLink = document.getElementById('repository-link');
                     repoLink.href = data.repoUrl;
                     repoLink.textContent = data.repoUrl;
-
-                    // Prepare data points for charts
-                    return Object.keys(data.entries).map((name) => ({
-                        name,
-                        dataSet: collectBenchesPerTestCase(data.entries[name]),
-                    }));
                 }
 
-                function createTitle(parent, name) {
-                    const nameElem = document.createElement('h1');
-                    nameElem.className = 'benchmark-title';
-                    nameElem.textContent = name;
-                    parent.appendChild(nameElem);
-                }
-
-                // input: separated-out datasets
-                function renderAllCharts(dataSets) {
-                    function createPlotsGroupBy(parent, groupBy, datasets, layout) {
-                        // group by (key1, key2, ...)
-
-                        // create title
-                        createTitle(parent, `Compare platform for ${groupBy}`);
-
-                        // group datasets by the relevant keys
-                        const groupedData = Object.groupBy(datasets, (d) => {
-                            const filter = {};
-                            for (let key of groupBy) {
-                                filter[key] = d.metadata[key];
-                            }
-                            return JSON.stringify(filter);
-                        });
-
-                        // create  a chart for each group
-                        let data = Object.entries(groupedData);
-                        for (let [key, value] of data) {
-                            // skip empty key
-                            if (key === '{}') {
-                                continue;
-                            }
-                            // unparse the groupBy keys
-                            let group = JSON.parse(key);
-                            const graphsElem = document.createElement('div');
-                            graphsElem.className = 'benchmark-graphs';
-                            parent.appendChild(graphsElem);
-                            chartByGroup(graphsElem, group, datasets, layout);
-                        }
-                    }
-                    function dataItemBelongsToGroup(d, groupBy) {
-                        // returns true if for every key in the groupBy entry,
-                        // the data item's value for that key (e.g. `os`: `windows_64`)
-                        // matches the value for this group.
-                        return Object.keys(groupBy).every(
-                            (key) => d.metadata[key] === groupBy[key] && d.metadata[key] !== undefined,
-                        );
-                    }
-                    function getOtherMetadataEntries(d, groupBy) {
-                        // returns the metadata keys that are not already
-                        // taken into account by the filter
-                        // and are not the unit key
-                        return Object.entries(d.metadata).filter(
-                            ([key, value]) => !Object.keys(groupBy).includes(key) && key !== 'unit',
-                        );
-                    }
-                    function chartByGroup(parent, group, datasets, layout) {
-                        const filtered = Array.from(
-                            datasets
-                                .filter((d) => dataItemBelongsToGroup(d, group))
-                                .map((trace) => {
-                                    // set the name in the legend
-                                    // construct the name using the other metadata keys
-                                    // that were not taken into account by the filter
-                                    const otherEntries = getOtherMetadataEntries(trace, groupBy);
-                                    trace.name = otherEntries
-                                        .map(([_k, v]) => v)
-                                        .filter((v) => v !== undefined)
-                                        .join(' ');
-
-                                    // set the tooltip text
-                                    trace.text = trace.dataset.map(
-                                        (d) =>
-                                            `<b>${trace.name}</b><br>value: ${d.bench.value} ${d.bench.unit} ${d.bench.range}<br>commit id: ${d.commit.id}<br>commit name: ${d.commit.message}<br>commit url: ${d.commit.url}`,
-                                    );
-                                    return trace;
-                                }),
-                        );
-
-                        const description = Object.entries(group)
-                            .map(([k, v]) => `${k}: ${v}`)
-                            .join(', ');
-                        // return if no datasets
-                        if (filtered.length == 0) {
-                            console.log(`No datasets found with ${description}`);
-                            return;
-                        }
-                        // get the unit from the first item (all are same, since this field is part of the key in `collectBenchesPerTestCase()`)
-                        // this is possible because there is at least one data point
-                        const unit = filtered[0].metadata.unit;
-
-                        // update layout
-                        layout.title = { text: description };
-                        layout.yaxis = { title: { text: `Value (${unit})` } };
-
-                        // create plot
-                        Plotly.newPlot(parent, filtered, layout);
-                    }
-
-                    function buildPlotConfig(dataSets) {
-                        const datasets = Array.from(
-                            dataSets.dataSet.map((item) => {
-                                let { name, api, keySize, category, os, platform, dataset, unit } = item;
-
-                                return {
-                                    metadata: {
-                                        category,
-                                        name,
-                                        api,
-                                        keySize,
-                                        os,
-                                        platform,
-                                        unit,
-                                    },
-                                    x: dataset.map((d) => new Date(d.commit.timestamp)),
-                                    y: dataset.map((d) => d.bench.value),
-                                    dataset,
-                                    showlegend: true,
-                                    hoverinfo: 'text',
-                                };
-                            }),
-                        );
-
-                        // extract GMT+offset from current time zone, if available
-                        const timeZone = new Date()
-                            .toString()
-                            .split(' ')
-                            .filter((s) => s.includes('GMT'))
-                            .map((s) => `(${s})`);
-
-                        const layout = {
-                            height: 600,
-                            width: 1200,
-                            xaxis: { title: { text: `Time of benchmark run ${timeZone}` }, type: 'date' },
-                        };
-
-                        return [datasets, layout];
-                    }
-
-                    const main = document.getElementById('main');
-                    const setElem = document.createElement('div');
-                    setElem.className = 'benchmark-set';
-                    main.appendChild(setElem);
-
-                    const [datasets, layout] = buildPlotConfig(dataSets[0]);
-
-                    let groupBy = window.BENCHMARK_DATA.groupBy;
-                    if (!groupBy || typeof groupBy !== 'object') {
-                        console.error('No or invalid groupBy provided: defaulting to `[os]`');
-                        groupBy = ['os'];
-                    }
-                    createPlotsGroupBy(setElem, groupBy, datasets, layout);
-                }
-
-                renderAllCharts(init()); // Start
+                init();
+                renderAllCharts();
             })();
         </script>
     </body>

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -209,10 +209,9 @@
 
                     return Array.from(traces);
                 }
+                // get the schema object from `window.BENCHMARK_DATA`,
+                // and return a default value if invalid or none is provided.
                 function retrieveSchema() {
-                    // get the schema object from `window.BENCHMARK_DATA`,
-                    // and return a default value if invalid or none is provided.
-
                     const defaultSchema = ['name', 'platform', 'os', 'keySize', 'api', 'category'];
 
                     let schema = window.BENCHMARK_DATA.schema;
@@ -222,10 +221,9 @@
                     }
                     return schema;
                 }
+                // get the groupBy object from `window.BENCHMARK_DATA`,
+                // and return a default value if invalid or none is provided.
                 function retrieveGroupBy() {
-                    // get the groupBy object from `window.BENCHMARK_DATA`,
-                    // and return a default value if invalid or none is provided.
-
                     const defaultGroupBy = ['os'];
                     let groupBy = window.BENCHMARK_DATA.groupBy;
                     if (!groupBy || typeof groupBy !== 'object') {
@@ -235,10 +233,10 @@
                     return groupBy;
                 }
 
+                // build the groupKey for a trace,
+                // which consists of the key-value pairs
+                // for the groupBy keys only.
                 function buildTraceGroupKey(trace, groupBy) {
-                    // build the groupKey for a trace,
-                    // which consists of the key-value pairs
-                    // for the groupBy keys only.
                     const traceGroup = {};
                     for (let key of groupBy) {
                         traceGroup[key] = trace.metadata[key];
@@ -255,12 +253,11 @@
 
                     return `<b>${name}</b><br>value: ${value} ${unit} ${range}<br>commit id: ${commitId}<br>commit name: ${message}<br>commit url: ${url}`;
                 }
+                // return the name for the graph legend,
+                // using only the metadata entries that are not included in the
+                // groupBy, and are not 'unit'.
+                // also, don't include the fields whose values are `undefined` in the name.
                 function getLegendName(trace, groupBy, schema) {
-                    // return the name for the graph legend,
-                    // using only the metadata entries that are not included in the
-                    // groupBy, and are not 'unit'.
-                    // also, don't include the fields whose values are `undefined` in the name.
-
                     // entries sorted by schema
                     const orderedEntries = schema.map((key) => [key, trace.metadata[key]]);
 
@@ -277,8 +274,8 @@
                     trace.text = trace.dataset.map((observation) => getObservationTooltipText(trace.name, observation));
                 }
 
+                // Display the fields in the group as a comma-separated list
                 function buildTitleFromGroupKey(groupKey, groupBy) {
-                    // Display the fields in the group as a comma-separated list
                     return groupBy
                         .map((field) => [field, groupKey[field]])
                         .map(([field, value]) => `${field}: ${value}`)

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -211,14 +211,28 @@
 
                     return Array.from(traces);
                 }
+                function retrieveSchema() {
+                    // get the schema object from `window.BENCHMARK_DATA`,
+                    // and return a default value if invalid or none is provided.
+
+                    const defaultSchema = ['name', 'platform', 'os', 'keySize', 'api', 'category', 'unit'];
+
+                    let schema = window.BENCHMARK_DATA.schema;
+                    if (!schema || typeof schema !== 'object') {
+                        console.error(`No or invalid groupBy provided: defaulting to [${defaultSchema}]`);
+                        schema = defaultSchema;
+                    }
+                    return schema;
+                }
                 function retrieveGroupBy() {
                     // get the groupBy object from `window.BENCHMARK_DATA`,
                     // and return a default value if invalid or none is provided.
 
+                    const defaultGroupBy = ['os'];
                     let groupBy = window.BENCHMARK_DATA.groupBy;
                     if (!groupBy || typeof groupBy !== 'object') {
-                        console.error('No or invalid groupBy provided: defaulting to `[os]`');
-                        groupBy = ['os'];
+                        console.error(`No or invalid groupBy provided: defaulting to [${defaultGroupBy}]`);
+                        groupBy = defaultGroupBy;
                     }
                     return groupBy;
                 }
@@ -278,12 +292,12 @@
                     const entries = window.BENCHMARK_DATA.entries;
                     const entry = Object.values(entries)[0];
 
+                    const schema = retrieveSchema();
+
                     // build the data traces by separating out the observations
                     // by key. This is equivalent to separating out the observations
                     // by benchmark id, except that the benchmark id consists
                     // of multiple, separate fields.
-                    // TODO: allow the user to specify the schema.
-                    const schema = ['name', 'platform', 'os', 'keySize', 'api', 'category', 'unit'];
                     const traces = separateAllTraces(entry, schema);
 
                     // get the groupBy information from `window.BENCHMARK_DATA`

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -109,6 +109,15 @@
         <script id="main-script">
             'use strict';
             (function () {
+                function timeZoneOffset() {
+                    // extract GMT+offset from current time zone, if available
+                    return new Date()
+                        .toString()
+                        .split(' ')
+                        .filter((s) => s.includes('GMT'))
+                        .map((s) => `(${s})`);
+                }
+
                 function buildPlotLayout() {
                     const offset = timeZoneOffset();
                     const layout = {
@@ -150,15 +159,6 @@
 
                     // add the plot to the elem
                     Plotly.newPlot(elem, filteredTraces, layout);
-                }
-
-                function timeZoneOffset() {
-                    // extract GMT+offset from current time zone, if available
-                    return new Date()
-                        .toString()
-                        .split(' ')
-                        .filter((s) => s.includes('GMT'))
-                        .map((s) => `(${s})`);
                 }
 
                 function buildKey(benchItem, schema) {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -173,6 +173,7 @@
                     const key = JSON.parse(keyString);
                     for (const s of schema) {
                         if (!key.hasOwnProperty(s)) {
+                            // explicitly set to `undefined`
                             key[s] = undefined;
                         }
                     }

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -96,13 +96,7 @@
             </div>
         </header>
         <main id="main"></main>
-        <footer>
-            <!--
-      <button id="dl-button">Download data as JSON</button>
-      <div class="spacer"></div>
-      <div class="small">Powered by <a rel="noopener" href="https://github.com/marketplace/actions/continuous-benchmark">github-action-benchmark</a></div>
-       -->
-        </footer>
+        <footer></footer>
 
         <script src="https://cdn.plot.ly/plotly-3.0.0.min.js" charset="utf-8"></script>
         <script src="data.js"></script>

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -219,7 +219,7 @@
 
                     let schema = window.BENCHMARK_DATA.schema;
                     if (!schema || typeof schema !== 'object') {
-                        console.error(`No or invalid groupBy provided: defaulting to [${defaultSchema}]`);
+                        console.error(`No or invalid schema provided: defaulting to [${defaultSchema}]`);
                         schema = defaultSchema;
                     }
                     return schema;

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -129,7 +129,7 @@
                 function chartFilteredTraces(parent, title, filteredTraces) {
                     // return if no datasets
                     if (filteredTraces.length == 0) {
-                        console.log(`No datasets found with ${description}`);
+                        console.error(`No datasets found with ${title}`);
                         return;
                     }
 

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -141,8 +141,8 @@
                     const layout = buildPlotLayout();
 
                     // get the unit from the first item
-                    // (all are same, since this field is part of the key in `collectBenchesPerTestCase()`)
-                    // this is possible because there is at least one data point
+                    // this is possible because there is at least one data point,
+                    // and the unit is the same across all data points.
                     const unit = filteredTraces[0].metadata.unit;
                     layout.yaxis = { title: { text: `Value (${unit})` } };
 

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -161,6 +161,9 @@
                     for (const s of schema) {
                         key[s] = benchItem[s];
                     }
+                    // include unit
+                    key.unit = benchItem.unit;
+
                     return JSON.stringify(key);
                 }
                 function parseKey(keyString, schema) {
@@ -210,7 +213,7 @@
                     // get the schema object from `window.BENCHMARK_DATA`,
                     // and return a default value if invalid or none is provided.
 
-                    const defaultSchema = ['name', 'platform', 'os', 'keySize', 'api', 'category', 'unit'];
+                    const defaultSchema = ['name', 'platform', 'os', 'keySize', 'api', 'category'];
 
                     let schema = window.BENCHMARK_DATA.schema;
                     if (!schema || typeof schema !== 'object') {

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -292,6 +292,8 @@
                     const entries = window.BENCHMARK_DATA.entries;
                     const entry = Object.values(entries)[0];
 
+                    // retrieve the custom metadata schema from `window.BENCHMARK_DATA`
+                    // each combination of fields is used to uniquely identify a trace
                     const schema = retrieveSchema();
 
                     // build the data traces by separating out the observations

--- a/src/load.ts
+++ b/src/load.ts
@@ -10,12 +10,8 @@ export interface BenchmarkResult {
     extra?: string;
     os: string;
 
-    // from NameMetadata
-    category?: string;
-    keySize?: number;
-    name: string;
-    platform?: string;
-    api?: string;
+    // from Metadata
+    [key: string]: any;
 }
 
 interface GitHubUser {

--- a/src/write.ts
+++ b/src/write.ts
@@ -16,6 +16,7 @@ export interface DataJson {
     repoUrl: string;
     entries: BenchmarkSuites;
     groupBy: string[];
+    schema: string[];
 }
 
 export const SCRIPT_PREFIX = 'window.BENCHMARK_DATA = ';
@@ -24,6 +25,7 @@ const DEFAULT_DATA_JSON = {
     repoUrl: '',
     entries: {},
     groupBy: ['os'],
+    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
 };
 
 async function loadDataJs(dataPath: string): Promise<DataJson> {
@@ -291,6 +293,7 @@ async function handleAlert(benchName: string, curSuite: Benchmark, prevSuite: Be
 
 function addBenchmarkToDataJson(
     groupBy: string[],
+    schema: string[],
     benchName: string,
     bench: Benchmark,
     data: DataJson,
@@ -303,6 +306,7 @@ function addBenchmarkToDataJson(
     data.lastUpdate = Date.now();
     data.groupBy = groupBy;
     data.repoUrl = htmlUrl;
+    data.schema = schema;
 
     // Add benchmark result
     if (data.entries[benchName] === undefined) {
@@ -353,6 +357,7 @@ async function writeBenchmarkToGitHubPagesWithRetry(
         skipFetchGhPages,
         maxItemsInChart,
         groupBy,
+        schema,
     } = config;
     const rollbackActions = new Array<() => Promise<void>>();
 
@@ -408,7 +413,7 @@ async function writeBenchmarkToGitHubPagesWithRetry(
     await io.mkdirP(benchmarkDataDirFullPath);
 
     const data = await loadDataJs(dataPath);
-    const prevBench = addBenchmarkToDataJson(groupBy, name, bench, data, maxItemsInChart);
+    const prevBench = addBenchmarkToDataJson(groupBy, schema, name, bench, data, maxItemsInChart);
 
     await storeDataJs(dataPath, data);
 
@@ -496,9 +501,9 @@ async function writeBenchmarkToExternalJson(
     jsonFilePath: string,
     config: Config,
 ): Promise<Benchmark | null> {
-    const { name, maxItemsInChart, saveDataFile, groupBy } = config;
+    const { name, maxItemsInChart, saveDataFile, groupBy, schema } = config;
     const data = await loadDataJson(jsonFilePath);
-    const prevBench = addBenchmarkToDataJson(groupBy, name, bench, data, maxItemsInChart);
+    const prevBench = addBenchmarkToDataJson(groupBy, schema, name, bench, data, maxItemsInChart);
 
     if (!saveDataFile) {
         core.debug('Skipping storing benchmarks in external data file');

--- a/test/extract.spec.ts
+++ b/test/extract.spec.ts
@@ -75,6 +75,7 @@ describe('loadResult()', function () {
         });
         const inputDataPath = path.join(__dirname, 'data', 'extract', test.file);
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const bench = await loadResult(config);
@@ -86,6 +87,7 @@ describe('loadResult()', function () {
 
     it('raises an error when output file is not readable', async function () {
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath: 'path/does/not/exist.txt',
         } as Config;
         await A.rejects(loadResult(config));
@@ -93,6 +95,7 @@ describe('loadResult()', function () {
 
     it('raises an error when no output found', async function () {
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath: path.join(__dirname, 'data', 'extract', 'invalid_output.txt'),
         } as Config;
         await A.rejects(loadResult(config), /^Error: No benchmark result was found in /);
@@ -116,6 +119,7 @@ describe('loadResult()', function () {
         };
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const { commit } = await loadResult(config);
@@ -159,6 +163,7 @@ describe('loadResult()', function () {
         };
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
             githubToken: 'abcd1234',
             ref: 'refs/pull/123/head',
@@ -218,6 +223,7 @@ describe('loadResult()', function () {
         };
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
             githubToken: 'abcd1234',
         } as Config;
@@ -252,6 +258,7 @@ describe('loadResult()', function () {
         dummyGitHubContext.payload = {};
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         await A.rejects(loadResult(config), /^Error: No commit information is found in payload/);

--- a/test/merge_group_extract.spec.ts
+++ b/test/merge_group_extract.spec.ts
@@ -78,6 +78,7 @@ describe('loadResult()', function () {
         });
         const inputDataPath = path.join(__dirname, 'data', 'extract', test.file);
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const bench = await loadResult(config);
@@ -91,6 +92,7 @@ describe('loadResult()', function () {
         dummyGitHubContext.payload = dummyWebhookPayload;
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const { commit } = await loadResult(config);
@@ -124,6 +126,7 @@ describe('loadResult()', function () {
         };
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const { commit } = await loadResult(config);
@@ -152,6 +155,7 @@ describe('loadResult()', function () {
         dummyGitHubContext.payload.merge_group.head_commit.committer = null;
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         const { commit } = await loadResult(config);
@@ -175,6 +179,7 @@ describe('loadResult()', function () {
         dummyGitHubContext.payload = {};
         const inputDataPath = path.join(__dirname, 'data', 'extract', 'customBiggerIsBetter_output.json');
         const config = {
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             inputDataPath,
         } as Config;
         await A.rejects(loadResult(config), /^Error: No commit information is found in payload/);

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -184,6 +184,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
         const dataJson = 'data.json';
         const defaultCfg: Config = {
             groupBy: ['os'],
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             name: 'Test benchmark',
             biggerIsBetter: false,
             inputDataPath: 'dummy', // Should not affect
@@ -237,6 +238,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -274,6 +276,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -299,6 +302,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -332,6 +336,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -372,6 +377,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -411,6 +417,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, name: 'Benchmark' },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -450,6 +457,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, alertCommentCcUsers: [] },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -487,6 +495,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, commentOnAlert: true, githubToken: 'dummy token' },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -513,6 +522,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, commentOnAlert: false, failOnAlert: false },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -540,6 +550,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: defaultCfg,
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -567,6 +578,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, commentOnAlert: true },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -594,6 +606,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, maxItemsInChart: 1 },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -636,6 +649,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, alertThreshold: 0, failThreshold: 0 },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -675,6 +689,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, failThreshold: 3 },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -716,6 +731,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                 config: { ...defaultCfg, failThreshold: 3 },
                 data: {
                     groupBy: ['os'],
+                    schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
                     lastUpdate,
                     repoUrl,
                     entries: {
@@ -898,6 +914,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
 
         const defaultCfg: Config = {
             groupBy: ['os'],
+            schema: ['name', 'platform', 'os', 'keySize', 'api', 'category'],
             name: 'Test benchmark',
             biggerIsBetter: false,
             inputDataPath: 'dummy', // Should not affect


### PR DESCRIPTION
This PR refactors the chart creation script:
- Unnest the function declarations
- Add error handling
- Simplify the data processing steps
- Move some logic into separate functions

It also allows a `schema` option to be provided to the action as a comma-separated list. This allows us to build the traces from the raw data points, where points that match a given combination of values for the schema keys are collected into one trace.