### PR TITLE
use benchmark action date rather than commit date

### DIFF
--- a/src/default_index.html
+++ b/src/default_index.html
@@ -199,7 +199,7 @@
 
                         return {
                             metadata,
-                            x: dataset.map((d) => new Date(d.commit.timestamp)),
+                            x: dataset.map((d) => new Date(d.date)),
                             y: dataset.map((d) => d.bench.value),
                             dataset,
                             showlegend: true,


### PR DESCRIPTION
Use the timestamp of the benchmark action run as the x-axis for the charts, rather than the commit timestamp.