### PR TITLE
Make comparison for failure when exceeding threshold based on key instead of name

### DIFF
--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-action-exceed-threshold]
     steps:
-      - name: Successful
+      - name: Successful - expected success
         if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-      - name: Failing
-        if: ${{ (contains(needs.*.result, 'failure')) }}
         run: exit 1
+      - name: Failing - expected failure
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 0

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -35,6 +35,7 @@ jobs:
           schema: 'name,os'
           fail-on-alert: true
           alert-threshold: 200%
+          bigger-is-better: false,
   # ensure that the above job fails
   check-action-fails-on-exceed-threshold:
     if: ${{ always() }}

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -20,8 +20,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages-test
-          group-by: 'os,keySize'
-          schema: 'os,keySize,name,platform,api,category'
+          group-by: 'os'
+          schema: 'name,os'
       - uses: ./ # local action in repo
         # Then add the data from part 2, which represents
         # more than a 200% increase.
@@ -31,8 +31,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           gh-pages-branch: gh-pages-test
-          group-by: 'os,keySize'
-          schema: 'os,keySize,name,platform,api,category'
+          group-by: 'os'
+          schema: 'name,os'
           fail-on-alert: true
           alert-threshold: 200%
   # ensure that the above job fails

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-action-exceed-threshold]
     steps:
-      - name: Successful - expected success
+      - name: Successful - expected failure but job exited successfully
         if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 1
       - name: Failing - expected failure

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -35,7 +35,6 @@ jobs:
           schema: 'name,os'
           fail-on-alert: true
           alert-threshold: 200%
-          bigger-is-better: false,
   # ensure that the above job fails
   check-action-fails-on-exceed-threshold:
     if: ${{ always() }}

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -1,0 +1,49 @@
+name: Test that the action fails if benchmark increase exceeds threshold
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  run-action-exceed-threshold:
+    runs-on: ubuntu-latest
+    steps:
+      # run the test using the local action in repo
+      - uses: actions/checkout@v4
+      - name: "build"
+        run: |
+          npm install
+          npm run build
+      - uses: ./ # local action in repo
+        # First add the data from part 1
+        with:
+          name: 'Test fail if exceed threshold'
+          input-data-path: ./test/data/extract/testFailPart1.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages-test
+          group-by: 'os,keySize'
+          schema: 'os,keySize,name,platform,api,category'
+      - uses: ./ # local action in repo
+        # Then add the data from part 2, which represents
+        # more than a 200% increase.
+        with:
+          name: 'Test fail if exceed threshold'
+          input-data-path: ./test/data/extract/testFailPart2.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: gh-pages-test
+          group-by: 'os,keySize'
+          schema: 'os,keySize,name,platform,api,category'
+          fail-on-alert: true
+          alert-threshold: 200%
+  # ensure that the above job fails
+  check-action-fails-on-exceed-threshold:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [run-action-exceed-threshold]
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -64,11 +64,17 @@ Input definitions are written in [action.yml](./action.yml).
 
 The grouping logic for the charts. This field specifies which data fields to group the charts by.
  
-### `schema` (Required)
+#### `schema` (Required)
 - Type: String
 - Default: `"name,platform,os,keySize,api,category"`
 
 The metadata schema for plots. This value must be a comma-separated list of strings.
+
+#### `bigger-is-better` (Required)
+- Type: Boolean
+- Default: `false`
+
+Whether a larger value of a benchmark observation is better for comparison purposes. This is used to generate alerts when new values increased beyond the provided threshold.
 
 #### `name` (Required)
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,4 +1,6 @@
 inputs:
+  bigger-is-better:
+    type: boolean
   group-by:
     type: string
   schema:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
   color: 'blue'
 
 inputs:
+  bigger-is-better:
+    description: 'Whether a larger value is better for comparison purposes'
+    required: true
+    default: false 
   group-by:
     description: 'Groups for plots. This value must be a comma-separated list of strings'
     required: true

--- a/src/write.ts
+++ b/src/write.ts
@@ -79,9 +79,6 @@ function benchmarkKey(benchmark: BenchmarkResult, schema: string[]): string {
     }
 
     const keyString = JSON.stringify(key);
-    console.log(schema);
-    console.log(keyString);
-    console.log(benchmark.os);
     return keyString;
 }
 

--- a/src/write.ts
+++ b/src/write.ts
@@ -69,14 +69,31 @@ interface Alert {
     ratio: number;
 }
 
-function findAlerts(curSuite: Benchmark, prevSuite: Benchmark, threshold: number): Alert[] {
+// construct the benchmark key using the schema,
+// so we can compare BenchmarkResults for the purpose
+// of generating alerts.
+function benchmarkKey(benchmark: BenchmarkResult, schema: string[]): string {
+    const key: any = {};
+    for (const s of schema) {
+        key[s] = benchmark[s];
+    }
+
+    const keyString = JSON.stringify(key);
+    console.log(schema);
+    console.log(keyString);
+    console.log(benchmark.os);
+    return keyString;
+}
+
+function findAlerts(curSuite: Benchmark, prevSuite: Benchmark, threshold: number, schema: string[]): Alert[] {
     core.debug(`Comparing current:${curSuite.commit.id} and prev:${prevSuite.commit.id} for alert`);
 
     const alerts = [];
     for (const current of curSuite.benches) {
-        const prev = prevSuite.benches.find((b) => b.name === current.name);
+        const currentKey = benchmarkKey(current, schema);
+        const prev = prevSuite.benches.find((b: BenchmarkResult) => benchmarkKey(b, schema) === currentKey);
         if (prev === undefined) {
-            core.debug(`Skipped because benchmark '${current.name}' is not found in previous benchmarks`);
+            core.debug(`Skipped because benchmark '${currentKey}' is not found in previous benchmarks`);
             continue;
         }
 
@@ -251,7 +268,7 @@ async function handleAlert(benchName: string, curSuite: Benchmark, prevSuite: Be
         return;
     }
 
-    const alerts = findAlerts(curSuite, prevSuite, alertThreshold);
+    const alerts = findAlerts(curSuite, prevSuite, alertThreshold, config.schema);
     if (alerts.length === 0) {
         core.debug('No performance alert found happily');
         return;

--- a/test/data/extract/testFailPart1.json
+++ b/test/data/extract/testFailPart1.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 1",
+        "unit": "Megabytes",
+        "value": 0
+    },
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 2",
+        "unit": "Megabytes",
+        "value": 1
+    },
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 3",
+        "unit": "Megabytes",
+        "value": 2
+    }
+]

--- a/test/data/extract/testFailPart1.json
+++ b/test/data/extract/testFailPart1.json
@@ -2,16 +2,19 @@
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 1",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 0
     },
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 2",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 1
     },
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 3",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 2
     }
 ]

--- a/test/data/extract/testFailPart2.json
+++ b/test/data/extract/testFailPart2.json
@@ -1,0 +1,18 @@
+
+[
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 1",
+        "unit": "Megabytes",
+        "value": 200
+    },
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 2",
+        "unit": "Megabytes",
+        "value": 200
+    },
+    {
+        "name": "My Custom Smaller Is Better Benchmark - Bench 3",
+        "unit": "Megabytes",
+        "value": 2
+    }
+]

--- a/test/data/extract/testFailPart2.json
+++ b/test/data/extract/testFailPart2.json
@@ -3,16 +3,19 @@
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 1",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 200
     },
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 2",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 200
     },
     {
         "name": "My Custom Smaller Is Better Benchmark - Bench 3",
         "unit": "Megabytes",
+	"os": "ubuntu-latest_64",
         "value": 2
     }
 ]

--- a/test/data/write/data-dir/original_data.js
+++ b/test/data/write/data-dir/original_data.js
@@ -16,7 +16,7 @@ window.BENCHMARK_DATA = {
                 },
                 "date": 1574927127603,
                 "tool": "cargo",
-                "benches": [{ "name": "bench_fib_10", "range": "± 20", "unit": "ns/iter", "value": 100 }]
+                "benches": [{ "name": "bench_fib_10", "range": "± 20", "unit": "ns/iter", "value": 100, "os": "ubuntu-latest"  }]
             }
         ]
     }


### PR DESCRIPTION
In the original action, when `fail-on-alert` is provided as `true`, each benchmark entry in the suite is checked against the data from the last run to ensure that the value did not increase beyond a provided threshold. However, since we now identify records by key (as a combination of fields) rather than by name, we need to adjust this check to compare entries by key rather than just by name.

It also documents the `bigger-is-better` field and specifies a default value.

This PR also adapts the test data accordingly, adds a CI workflow to test that the alert is generated correctly.