### PR TITLE
Fixes and improvements to the benchmarking action

### DIFF
--- a/src/default_index.html
+++ b/src/default_index.html
@@ -610,6 +610,14 @@
                     main.appendChild(filterElem);
                     main.appendChild(setElem);
                 }
+                async function checkFileAvailable(url) {
+                    const response = await fetch(url, { method: 'HEAD' }).catch((e) => {
+                        throw new Error(`Error retrieving data from ${url}: ${e}`);
+                    });
+                    if (response.status !== 200) {
+                        throw new Error(`Error retrieving data from ${url}: ${response.statusText}`);
+                    }
+                }
                 async function loadDataFromUrl(url) {
                     const response = await fetch(url).catch((e) => {
                         throw new Error(`Error retrieving data from ${url}: ${e}`);
@@ -647,7 +655,7 @@
                         const promises = listing.refs.map(async (ref) => {
                             let keep = true;
                             try {
-                                await loadDataFromRef(ref);
+                                await checkFileAvailable(`${ref}.json`);
                             } catch (e) {
                                 console.error(`Skipping ref in listing: ${e}`);
                                 keep = false;
@@ -663,7 +671,7 @@
                         const promises = listing.prs.map(async (pr) => {
                             let keep = true;
                             try {
-                                await loadDataFromPr(pr);
+                                await checkFileAvailable(`pr/${pr}.json`);
                             } catch (e) {
                                 console.error(`Skipping pr in listing: ${e}`);
                                 keep = false;

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -109,7 +109,7 @@
         </header>
         <main id="main">
             <div class="dropdowns">
-                <div id="branch-pr-dropdown"></div>
+                <div id="ref-pr-dropdown"></div>
                 <div id="benchmark-set-dropdown"></div>
             </div>
             <div id="body"></div>
@@ -482,28 +482,28 @@
                         elem.appendChild(checklist);
                     });
                 }
-                function populateBranchPrDropdown(branchesOpt, prsOpt) {
-                    let elem = document.getElementById('branch-pr-dropdown');
+                function populateRefPrDropdown(refsOpt, prsOpt) {
+                    let elem = document.getElementById('ref-pr-dropdown');
                     elem.innerHTML = '';
 
-                    const branches = branchesOpt ? branchesOpt : [];
+                    const refs = refsOpt ? refsOpt : [];
                     const prs = prsOpt ? prsOpt : [];
 
-                    // if there are no branches or prs, remove the dropdown
-                    if (branches.length == 0 && prs.length == 0) {
+                    // if there are no refs or prs, remove the dropdown
+                    if (refs.length == 0 && prs.length == 0) {
                         return;
                     }
                     const label = document.createElement('label');
-                    label.setAttribute('for', 'branch-pr-dropdown');
+                    label.setAttribute('for', 'ref-pr-dropdown');
                     elem.appendChild(label);
 
                     const select = document.createElement('select');
-                    select.id = 'branch-pr-dropdown';
+                    select.id = 'ref-pr-dropdown';
                     elem.appendChild(select);
 
-                    branches.forEach((name) => {
+                    refs.forEach((name) => {
                         const option = document.createElement('option');
-                        const text = `branch ${name}`;
+                        const text = `ref ${name}`;
                         option.setAttribute('value', text);
                         option.textContent = text;
                         select.appendChild(option);
@@ -521,7 +521,7 @@
                         if (type === 'pr') {
                             await loadDataFromPr(value);
                         } else {
-                            await loadDataFromBranch(value);
+                            await loadDataFromRef(value);
                         }
                         rerenderAll();
                     });
@@ -617,8 +617,8 @@
                         })
                         .then((response) => response.json());
                 }
-                async function loadDataFromBranch(branch) {
-                    const dataUrl = `branch/refs/heads/${branch}.json`;
+                async function loadDataFromRef(ref) {
+                    const dataUrl = `${ref}.json`;
                     window.BENCHMARK_DATA = await loadDataFromUrl(dataUrl);
                     return window.BENCHMARK_DATA;
                 }
@@ -637,10 +637,10 @@
                     renderAllCharts(benchSet);
                 }
                 async function loadFirstDataset(listing) {
-                    if (listing.branches) {
-                        for (const branch of listing.branches) {
+                    if (listing.refs) {
+                        for (const ref of listing.refs) {
                             try {
-                                return await loadDataFromBranch(branch);
+                                return await loadDataFromRef(ref);
                             } catch (e) {
                                 console.error(e);
                                 continue;
@@ -662,7 +662,7 @@
 
                 async function init() {
                     const listing = await loadDataFromUrl('listing.json');
-                    populateBranchPrDropdown(listing.branches, listing.prs);
+                    populateRefPrDropdown(listing.refs, listing.prs);
 
                     const data = await loadFirstDataset(listing);
                     // Render header

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -394,7 +394,8 @@
                     });
                     filteredCharts.forEach((chart) => {
                         let hiddenByAttribute = chart.getAttribute('hidden-by');
-                        let hiddenBy = hiddenByAttribute ? hiddenByAttribute : 0;
+                        let hiddenBy = hiddenByAttribute ? Number(hiddenByAttribute) : 0;
+                        hiddenBy = hiddenBy ? hiddenBy : 0;
 
                         if (hide) {
                             chart.style.setProperty('display', 'none');

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -611,11 +611,17 @@
                     main.appendChild(setElem);
                 }
                 async function loadDataFromUrl(url) {
-                    return fetch(url)
-                        .catch((e) => {
-                            throw new Error(`Error retrieving data from ${url}: ${e}`);
-                        })
-                        .then((response) => response.json());
+                    const response = await fetch(url).catch((e) => {
+                        throw new Error(`Error retrieving data from ${url}: ${e}`);
+                    });
+                    if (response.status !== 200) {
+                        throw new Error(`Error retrieving data from ${url}: ${response.statusText}`);
+                    }
+                    try {
+                        return response.json();
+                    } catch (e) {
+                        throw new Error(`Error parsing JSON from ${url}: ${e}`);
+                    }
                 }
                 async function loadDataFromRef(ref) {
                     const dataUrl = `${ref}.json`;
@@ -636,32 +642,55 @@
                     populateBenchSetDropdown(Object.keys(benchSets));
                     renderAllCharts(benchSet);
                 }
-                async function loadFirstDataset(listing) {
+                async function filterListing(listing) {
                     if (listing.refs) {
-                        for (const ref of listing.refs) {
+                        const promises = listing.refs.map(async (ref) => {
+                            let keep = true;
                             try {
-                                return await loadDataFromRef(ref);
+                                await loadDataFromRef(ref);
                             } catch (e) {
-                                console.error(e);
-                                continue;
+                                console.error(`Skipping ref in listing: ${e}`);
+                                keep = false;
                             }
-                        }
+                            return { keep, ref };
+                        });
+
+                        listing.refs = (await Promise.all(promises))
+                            .filter((result) => result.keep)
+                            .map((result) => result.ref);
                     }
                     if (listing.prs) {
-                        for (const pr of listing.prs) {
+                        const promises = listing.prs.map(async (pr) => {
+                            let keep = true;
                             try {
-                                return await loadDataFromPr(pr);
+                                await loadDataFromPr(pr);
                             } catch (e) {
-                                console.error(e);
-                                continue;
+                                console.error(`Skipping pr in listing: ${e}`);
+                                keep = false;
                             }
-                        }
+                            return { keep, pr };
+                        });
+
+                        listing.prs = (await Promise.all(promises))
+                            .filter((result) => result.keep)
+                            .map((result) => result.pr);
+                    }
+                }
+                async function loadFirstDataset(listing) {
+                    if (listing.refs) {
+                        return await loadDataFromRef(listing.refs[0]);
+                    }
+                    if (listing.prs) {
+                        return await loadDataFromPr(listing.prs[0]);
                     }
                     throw new Error('listing contains no valid datasets');
                 }
 
                 async function init() {
                     const listing = await loadDataFromUrl('listing.json');
+
+                    await filterListing(listing);
+
                     populateRefPrDropdown(listing.refs, listing.prs);
 
                     const data = await loadFirstDataset(listing);

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -382,14 +382,14 @@
                 }
                 function addAttributesToChartElement(elem, groupKey) {
                     Object.entries(groupKey).forEach(([key, value]) => {
-                        elem.setAttribute(key, value);
+                        elem.setAttribute(key.replace(' ', ''), value);
                     });
                 }
 
                 function setChartHiddenStatus(hide, key, value) {
                     const charts = document.getElementsByClassName('benchmark-graphs');
                     const filteredCharts = Array.from(charts).filter((chart) => {
-                        const chartValue = chart.getAttribute(key);
+                        const chartValue = chart.getAttribute(key.replace(' ', ''));
                         return chartValue === value;
                     });
                     filteredCharts.forEach((chart) => {
@@ -618,7 +618,7 @@
                         .then((response) => response.json());
                 }
                 async function loadDataFromBranch(branch) {
-                    const dataUrl = `branch/${branch}.json`;
+                    const dataUrl = `branch/refs/heads/${branch}.json`;
                     window.BENCHMARK_DATA = await loadDataFromUrl(dataUrl);
                     return window.BENCHMARK_DATA;
                 }

--- a/src/default_index.html
+++ b/src/default_index.html
@@ -685,10 +685,10 @@
                     }
                 }
                 async function loadFirstDataset(listing) {
-                    if (listing.refs) {
+                    if (listing.refs[0]) {
                         return await loadDataFromRef(listing.refs[0]);
                     }
-                    if (listing.prs) {
+                    if (listing.prs[0]) {
                         return await loadDataFromPr(listing.prs[0]);
                     }
                     throw new Error('listing contains no valid datasets');

--- a/src/write.ts
+++ b/src/write.ts
@@ -658,8 +658,10 @@ export async function writeBenchmark(bench: Benchmark, config: Config) {
 
     let prevBench;
     if (externalDataJsonPath) {
+        console.log('Writing to external JSON');
         prevBench = await writeBenchmarkToExternalJson(bench, externalDataJsonPath, config);
     } else {
+        console.log('Writing to GitHub Pages');
         prevBench = await getPrevBench(name, config);
         await writeBenchmarkToGitHubPages(bench, config);
     }

--- a/src/write.ts
+++ b/src/write.ts
@@ -533,6 +533,7 @@ async function writeBenchmarkToGitHubPagesWithRetry(bench: Benchmark, config: Co
     if (!dataRelativePath) {
         // sometimes we don't want to push the benchmark data (e.g. on the merge queue).
         // in this case, skip the below.
+        console.warn('No data path could be built');
         return;
     }
     const dataPath = path.join(benchmarkBaseDir, dataRelativePath);
@@ -616,6 +617,9 @@ async function writeBenchmarkToGitHubPages(bench: Benchmark, config: Config) {
     try {
         await writeBenchmarkToGitHubPagesWithRetry(bench, config, 10);
         return;
+    } catch (e) {
+        console.warn(e);
+        throw e;
     } finally {
         if (!ghRepository) {
             // `git switch` does not work for backing to detached head

--- a/src/write.ts
+++ b/src/write.ts
@@ -59,20 +59,21 @@ function getDataPath(config: Config) {
 function getComparePathAndSha(config: Config): [string, string] | undefined {
     const eventName = github.context.eventName;
 
-    let branch: string;
+    let ref: string;
     let sha: string;
     if (eventName === 'pull_request') {
-        branch = github.context.payload.pull_request?.base.ref;
+        const branch = github.context.payload.pull_request?.base.ref;
         sha = github.context.payload.pull_request?.base.sha;
         if (!branch || !sha) {
             console.warn(`ref ${branch} or sha ${sha} is null; skipping`);
             return undefined;
         }
+        ref = path.join('refs', 'heads', branch);
     } else if (eventName === 'merge_group') {
-        branch = github.context.payload.merge_group.base_ref;
+        ref = github.context.payload.merge_group.base_ref;
         sha = github.context.payload.merge_group.base_sha;
     } else if (eventName === 'push') {
-        branch = github.context.ref;
+        ref = github.context.ref;
         sha = github.context.payload.before;
     } else {
         return undefined;
@@ -82,7 +83,7 @@ function getComparePathAndSha(config: Config): [string, string] | undefined {
         return undefined;
     }
 
-    const file = `${branch}.json`;
+    const file = `${ref}.json`;
     const comparePath = path.join(config.basePath, 'branch', file);
 
     return [comparePath, sha];
@@ -538,7 +539,7 @@ async function writeBenchmarkToGitHubPagesWithRetry(bench: Benchmark, config: Co
     }
     const dataPath = path.join(benchmarkBaseDir, dataRelativePath);
 
-    const branchPath = path.join(benchmarkBaseDir, basePath, 'branch');
+    const branchPath = path.join(benchmarkBaseDir, basePath, 'branch', 'refs', 'heads');
     const prPath = path.join(benchmarkBaseDir, basePath, 'pr');
     await io.mkdirP(path.join(benchmarkBaseDir, basePath));
     await io.mkdirP(branchPath);

--- a/src/write.ts
+++ b/src/write.ts
@@ -47,7 +47,6 @@ interface DataEntry {
     id: string;
 }
 
-// TODO: break up into 'info' and 'path' functions
 function getDataEntry(): DataEntry | undefined {
     const eventName = github.context.eventName;
 

--- a/src/write.ts
+++ b/src/write.ts
@@ -53,6 +53,8 @@ function getDataPath(config: Config) {
         file = `${push.base_ref}.json`;
         directory = 'branch';
     } else {
+        console.warn(`Unsupported event type: ', ${github.context.eventName}`);
+        core.debug(JSON.stringify(github.context.payload));
         return undefined;
     }
 

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -909,21 +909,21 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             gitSpy.clear();
             delete (global as any).window;
             for (const p of [
-                path.join('data-dir', 'branch'),
+                path.join('data-dir', 'refs'),
                 path.join('data-dir', 'pr', '10.json'),
                 path.join('data-dir', 'index.html'),
                 path.join('data-dir', 'listing.json'),
                 'new-data-dir',
-                path.join('with-index-html', 'branch'),
+                path.join('with-index-html', 'refs'),
                 path.join('with-index-html', 'pr'),
                 path.join('with-index-html', 'listing.json'),
                 path.join('with-index-html', 'data.json'),
                 path.join('benchmark-data-repository', 'data-dir', 'data.json'),
                 path.join('benchmark-data-repository', 'data-dir', 'listing.json'),
-                path.join('benchmark-data-repository', 'data-dir', 'branch'),
+                path.join('benchmark-data-repository', 'data-dir', 'refs'),
                 path.join('benchmark-data-repository', 'data-dir', 'index.html'),
                 path.join('benchmark-data-repository', 'new-data-dir'),
-                path.join('benchmark-data-repository', 'branch'),
+                path.join('benchmark-data-repository', 'refs'),
                 path.join('benchmark-data-repository', 'pr'),
                 path.join('benchmark-data-repository', 'listing.json'),
                 path.join('benchmark-data-repository', 'index.html'),
@@ -1003,7 +1003,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             } = {},
         ): [GitFunc, unknown[]][] {
             const baseDir = cfg.baseDir ?? 'data-dir';
-            const dataPathRelative = cfg.dataPath ?? path.join('branch', 'refs', 'heads', 'main.json');
+            const dataPathRelative = cfg.dataPath ?? path.join('refs', 'heads', 'main.json');
             const dataPath = path.join(baseDir, dataPathRelative);
             const listingPath = path.join(baseDir, 'listing.json');
             const indexHtmlPath = path.join(baseDir, 'index.html');
@@ -1073,7 +1073,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                     bigger_is_better: false,
                 },
                 gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ dataPath: 'branch/refs/heads/main.json' }),
+                gitHistory: gitHistory({ dataPath: 'refs/heads/main.json' }),
             },
             {
                 it: 'appends new data in other repository',
@@ -1111,7 +1111,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                         [
                             ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
                             'add',
-                            path.join('data-dir', 'branch/refs/heads/main.json'),
+                            path.join('data-dir', 'refs/heads/main.json'),
                         ],
                     ],
                     [
@@ -1179,7 +1179,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                         [
                             ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
                             'add',
-                            path.join('branch', 'refs', 'heads', 'main.json'),
+                            path.join('refs', 'heads', 'main.json'),
                         ],
                     ],
                     [
@@ -1436,7 +1436,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
         for (const t of normalCasesWithPayloadType) {
             // FIXME: can't use `it.each` currently as tests running in parallel interfere with each other
             it(t.it, async function () {
-                const dataJsRelative = path.join('branch', 'refs', 'heads', 'main.json');
+                const dataJsRelative = path.join('refs', 'heads', 'main.json');
                 if (t.payloadType === PayloadType.PullRequest) {
                     contextSetPullRequest(gitHubContext, 10, 'main', 'prev commit id');
                 } else if (t.payloadType === PayloadType.MergeGroup) {
@@ -1614,13 +1614,13 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             };
 
             const originalDataJs = path.join(config.basePath, 'original_data.json');
-            const dataJs = path.join(config.basePath, 'branch', 'refs', 'heads', 'main.json');
-            await fs.mkdir(path.join(config.basePath, 'branch', 'refs', 'heads'), { recursive: true });
+            const dataJs = path.join(config.basePath, 'refs', 'heads', 'main.json');
+            await fs.mkdir(path.join(config.basePath, 'refs', 'heads'), { recursive: true });
             await fs.copyFile(originalDataJs, dataJs);
 
             const history = gitHistory({
                 addIndexHtml: false,
-                dataPath: 'branch/refs/heads/main.json',
+                dataPath: 'refs/heads/main.json',
                 baseDir: 'with-index-html',
             });
             if (t.pushErrorCount > 0) {

--- a/test/write.spec.ts
+++ b/test/write.spec.ts
@@ -73,7 +73,7 @@ const gitHubContext = {
         merge_group: null as any,
     },
     workflow: 'Workflow name',
-    ref: 'main', // TODO: set separately for pull request tests
+    ref: 'refs/heads/main', // TODO: set separately for pull request tests
 };
 
 enum PayloadType {
@@ -1003,7 +1003,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             } = {},
         ): [GitFunc, unknown[]][] {
             const baseDir = cfg.baseDir ?? 'data-dir';
-            const dataPathRelative = cfg.dataPath ?? path.join('branch', 'main.json');
+            const dataPathRelative = cfg.dataPath ?? path.join('branch', 'refs', 'heads', 'main.json');
             const dataPath = path.join(baseDir, dataPathRelative);
             const listingPath = path.join(baseDir, 'listing.json');
             const indexHtmlPath = path.join(baseDir, 'index.html');
@@ -1073,7 +1073,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                     bigger_is_better: false,
                 },
                 gitServerUrl: serverUrl,
-                gitHistory: gitHistory({ dataPath: 'branch/main.json' }),
+                gitHistory: gitHistory({ dataPath: 'branch/refs/heads/main.json' }),
             },
             {
                 it: 'appends new data in other repository',
@@ -1111,7 +1111,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                         [
                             ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
                             'add',
-                            path.join('data-dir', 'branch/main.json'),
+                            path.join('data-dir', 'branch/refs/heads/main.json'),
                         ],
                     ],
                     [
@@ -1179,7 +1179,7 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
                         [
                             ['--work-tree=./benchmark-data-repository', '--git-dir=./benchmark-data-repository/.git'],
                             'add',
-                            path.join('branch', 'main.json'),
+                            path.join('branch', 'refs', 'heads', 'main.json'),
                         ],
                     ],
                     [
@@ -1436,11 +1436,11 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
         for (const t of normalCasesWithPayloadType) {
             // FIXME: can't use `it.each` currently as tests running in parallel interfere with each other
             it(t.it, async function () {
-                const dataJsRelative = path.join('branch', 'main.json');
+                const dataJsRelative = path.join('branch', 'refs', 'heads', 'main.json');
                 if (t.payloadType === PayloadType.PullRequest) {
                     contextSetPullRequest(gitHubContext, 10, 'main', 'prev commit id');
                 } else if (t.payloadType === PayloadType.MergeGroup) {
-                    contextSetMergeGroup(gitHubContext, 'main', 'prev commit id');
+                    contextSetMergeGroup(gitHubContext, 'refs/heads/main', 'prev commit id');
                 } else {
                     contextSetPush(gitHubContext, 'prev commit id');
                 }
@@ -1614,13 +1614,13 @@ describe.each(['https://github.com', 'https://github.enterprise.corp'])('writeBe
             };
 
             const originalDataJs = path.join(config.basePath, 'original_data.json');
-            const dataJs = path.join(config.basePath, 'branch', 'main.json');
-            await fs.mkdir(path.join(config.basePath, 'branch'), { recursive: true });
+            const dataJs = path.join(config.basePath, 'branch', 'refs', 'heads', 'main.json');
+            await fs.mkdir(path.join(config.basePath, 'branch', 'refs', 'heads'), { recursive: true });
             await fs.copyFile(originalDataJs, dataJs);
 
             const history = gitHistory({
                 addIndexHtml: false,
-                dataPath: 'branch/main.json',
+                dataPath: 'branch/refs/heads/main.json',
                 baseDir: 'with-index-html',
             });
             if (t.pushErrorCount > 0) {


### PR DESCRIPTION
Some general fixes and improvements to the action.
- Organize data by the more general `ref` instead of `branch`
- Better handling of event type and better data path construction
- More debug information
- Only populate dropdown with available files
- Fix bug in checkboxes where the number of keys a chart is hidden by was not parsed as a number