### PR TITLE
bugfix for handling of numeric metadata values

### DIFF
--- a/src/default_index.html
+++ b/src/default_index.html
@@ -201,7 +201,11 @@
                     // build the key from the values in the schema
                     let key = {};
                     for (const s of schema) {
-                        key[s] = benchItem[s];
+                        let value = benchItem[s];
+                        if (typeof value === 'number') {
+                            value = value.toString();
+                        }
+                        key[s] = value;
                     }
 
                     return JSON.stringify(key);
@@ -341,7 +345,11 @@
                 function buildTraceGroupKey(trace, groupBy) {
                     const traceGroup = {};
                     for (let key of groupBy) {
-                        traceGroup[key] = trace.metadata[key];
+                        let value = trace.metadata[key];
+                        if (typeof value === 'number') {
+                            value = value.toString();
+                        }
+                        traceGroup[key] = value;
                     }
                     return JSON.stringify(traceGroup);
                 }


### PR DESCRIPTION
This PR fixes a bug in the `index.html` chart code, where numeric metadata values in the dataset were not converted into strings first before computing lists of unique values.